### PR TITLE
Introduce `pcard`

### DIFF
--- a/src/home/home.html
+++ b/src/home/home.html
@@ -6,27 +6,27 @@
       <div class="subtitle">
         An interface for DAO to DAO interactions, such as token swaps, co-liquidity provision, and joint venture formation.
       </div>
-      <div class="buttons">
-        <div class="buttonContainer">
-          <div class="contribute" click.delegate="navigate('deals')">
-            <div class="title">
-              <div class="header">All Deals</div>
-              <div class="arrow">&#8599;</div>
-            </div>
+      <div class="cards">
+        <pcard type="default" width="360px" click.delegate="navigate('deals')">
+          <div slot="header">
+            <div class="text left">All Deals</div>
+            <div class="icon right">&#8599;</div>
+          </div>
+          <div slot="body">
             <div class="icon"></div>
             <div class="subtitle">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
           </div>
-        </div>
-        <div class="buttonContainer">
-          <div class="launch" click.delegate="navigate('initiate')">
-            <div class="title">
-              <div class="header">Initiate a Deal</div>
-              <div class="arrow">&#8599;</div>
-            </div>
+        </pcard>
+        <pcard type="default" width="360px" click.delegate="navigate('initiate')">
+          <div slot="header">
+            <div class="text">Initiate a Deal</div>
+            <div class="icon">&#8599;</div>
+          </div>
+          <div slot="body">
             <div class="icon"></div>
             <div class="subtitle">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</div>
           </div>
-        </div>
+        </pcard>
       </div>
     </div>
 
@@ -44,7 +44,7 @@
           ></deal-summary>
         </horizontal-scroller>
         <div class="dealsButton">
-          <div class="buttonContainer centered">
+          <div class="centered">
             <pbutton 
               type="tertiary" 
               click.delegate="navigate('deals')" 
@@ -66,7 +66,7 @@
         <div class="subtitle subtext gradient">Subtitle</div>
         <div class="title heading heading1">Web3 partnerships made easy!</div>
         <div class="disclaimer subtext">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</div>
-        <div class="buttonContainer">
+        <div class="cardContainer">
           <pbutton 
             type="secondary"
             click.delegate="navigate('initiate')" 

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -9,8 +9,8 @@
       <div class="cards">
         <pcard type="default" width="360px" click.delegate="navigate('deals')">
           <div slot="header">
-            <div class="text left">All Deals</div>
-            <div class="icon right">&#8599;</div>
+            <span class="text left">All Deals</span>
+            <span class="icon center">&#8599;</span>
           </div>
           <div slot="body">
             <div class="icon"></div>
@@ -19,8 +19,8 @@
         </pcard>
         <pcard type="default" width="360px" click.delegate="navigate('initiate')">
           <div slot="header">
-            <div class="text">Initiate a Deal</div>
-            <div class="icon">&#8599;</div>
+            <span class="text">Initiate a Deal</span>
+            <span class="icon">&#8599;</span>
           </div>
           <div slot="body">
             <div class="icon"></div>

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -26,7 +26,6 @@
 
 
     &.top {
-      width: 56%;
       margin-bottom: 200px;
 
       .title {
@@ -49,61 +48,13 @@
         white-space: normal;
       }
 
-      .buttons {
-        display: grid;
-        grid-auto-flow: column;
-        justify-content: space-between;
+      .cards {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: start;
         cursor: pointer;
-        width: 710px;
         grid-gap: 24px;
-        .buttonContainer {
-          display: flex;
-          border-radius: 6px;
-          overflow: hidden;
-          & .header {
-            -webkit-text-fill-color: white;
-          }
-        }
-        .contribute,
-        .launch {
-          border-left-width: 6px;
-          border-right-width: 0;
-          border-left-style: solid;
-          border-image: linear-gradient(to bottom, #ff497a, #a258a7) 1 100%;
-          border-radius: 6px;
-          background-color: $BG02;
-          width: 300px;
-
-          padding: 18px;
-
-          .title {
-            display: flex;
-            justify-content: space-between;
-            color: $White;
-            margin-bottom: 16px;
-            margin-right: 6px;
-
-            .header {
-              font-weight: bold;
-              font-family: "Aeonik";
-              font-size: 28px;
-              white-space: nowrap;
-              padding-right: 16px;
-            }
-
-            .arrow {
-              font-size: 28px;
-            }
-          }
-
-          .subtitle {
-            color: $Neutral03;
-            font-size: 16px;
-            line-height: 20px;
-            font-weight: 400;
-            font-family: "Inter";
-          }
-        }
       }
     }
 

--- a/src/resources/elements/dealSummary/dealSummary.html
+++ b/src/resources/elements/dealSummary/dealSummary.html
@@ -1,13 +1,11 @@
 <template>
-  <div 
+  <pcard 
     class="dealSummaryContainer"
+    width="360px"
     ref="container"
   >
   <!-- Open Deal -->
-    <div if.to-view="!loading" class="dealSummary">
-      <div class="countdown">
-        <time-left deal.to-view="deal" largest contained></time-left>
-      </div>
+    <div slot="body" if.to-view="!loading" class="dealSummary">
       <div class="proposal">
         <div class="title ellipses">
           <h1>${deal.type}</h1>
@@ -18,7 +16,6 @@
         </div>
       </div> 
       <div class="footer">
-        <div>
           <div class="icons ${!deal.dao.creator?'open':'running'}">
             <div if.to-view="deal.logo.creator" class="icon">
               <img src="${deal.logo.creator}" />
@@ -34,15 +31,13 @@
           <pbutton
             type="secondary"
             click.delegate="navigate('initiate')">
-            Partner
+            View
           </pbutton>
-        </div>
       </div>
     </div>
 
-    <div if.to-view="loading" class="loading">
+    <div else class="loading">
       <i class="fas fa-circle-notch fa-spin"></i>
     </div>
-
-  </div>
+  </pcard>
 </template>

--- a/src/resources/elements/dealSummary/dealSummary.scss
+++ b/src/resources/elements/dealSummary/dealSummary.scss
@@ -1,42 +1,42 @@
 @import "styles/colors.scss";
 .dealSummaryContainer {
-  display: inline-block;
-  cursor: default;
-  width: 360px;
-  height: 291px;
-  padding-right: 30px;
-
-  .dealSummary {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 34px 190px 67px;
-    grid-template-areas:
-      "countdown"
-      "proposal"
-      "footer";
+  .cardContainer {
+    display: inline-block;
+    margin-right: 30px;
     background-color: $BG02;
     transition: 0.35s ease-in-out;
-    .button {
-      width: 134px;
-      &:after {
-        background-color: $BG02;
-      }
+    .card {
+      background-color: unset;
     }
     &:hover {
-      background-color: #403453;
-      .button:after {
-        opacity: 0;
-      }
+      background-color: $Border01;
+      // .button:after {
+      //   opacity: 0;
+      // }
       .icons>.icon {
-        border-color: #403453;
+        border-color: $Border01;
       }
       .title>h1 {
         color: #897AA1;
       }
     }
-    border-radius: 6px;
-    padding: 0 8px 0 20px;
-    box-sizing: border-box;
+  }
+  // cursor: default;
+  height: 291px;
+
+  .dealSummary {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 208px 47px;
+    grid-template-areas:
+      "proposal"
+      "footer";
+    .button {
+      width: 134px;
+    }
+    // border-radius: 6px;
+    // padding: 0 8px 0 20px;
+    // box-sizing: border-box;
     height: 100%;
     overflow: hidden;
     align-items: center;
@@ -152,9 +152,7 @@
       grid-area: footer;
       display: flex;
       align-items: baseline;
-      height: 67px;
 
-      &>div {
         .button {
           margin: 0;
           margin-right: 12px;
@@ -169,7 +167,6 @@
         font-weight: bold;
         font-size: 13px;
       }
-    }
   }
 
   .loading {

--- a/src/resources/elements/dealSummary/dealSummary.ts
+++ b/src/resources/elements/dealSummary/dealSummary.ts
@@ -1,8 +1,6 @@
 import { autoinject } from "aurelia-framework";
 import { Router } from "aurelia-router";
 import { bindable } from "aurelia-typed-observable-plugin";
-// import { Deal } from "entities/Deal";
-// import { DealService } from "services/DealService";
 import { Address } from "services/EthereumService";
 import "./dealSummary.scss";
 
@@ -19,12 +17,9 @@ export class DealSummary {
 
   constructor(
     private router: Router,
-    // private dealService: DealService,
   ) {}
 
   async attached(): Promise<void> {
-    // await this.dealService.ensureInitialized();
-    // this.deal = this.dealService.deals.get(this.address);
     this.loading = false;
   }
 

--- a/src/resources/elements/primeDesignSystem/index.ts
+++ b/src/resources/elements/primeDesignSystem/index.ts
@@ -4,5 +4,6 @@ import { PLATFORM } from "aurelia-pal";
 export function configure(config: FrameworkConfiguration): void {
   config.globalResources([
     PLATFORM.moduleName("./pbutton/pbutton"),
+    PLATFORM.moduleName("./pcard/pcard"),
   ]);
 }

--- a/src/resources/elements/primeDesignSystem/pcard/pcard.html
+++ b/src/resources/elements/primeDesignSystem/pcard/pcard.html
@@ -1,0 +1,9 @@
+<template>
+  <div class="cardContainer" style="width: ${width};">
+    <section class="card ${type}">
+      <slot name="header"></slot>
+      <slot name="body"></slot>
+      <slot name="footer"></slot>
+    </section>
+  </div>
+</template>

--- a/src/resources/elements/primeDesignSystem/pcard/pcard.scss
+++ b/src/resources/elements/primeDesignSystem/pcard/pcard.scss
@@ -1,0 +1,111 @@
+@import "styles/styles.scss";
+
+.cardContainer {
+  border-radius: 6px;
+  overflow: hidden;
+  & .header {
+    -webkit-text-fill-color: white;
+  }
+}
+
+.card {
+  border-radius: 6px;
+  background-color: $BG02;
+  cursor: pointer;
+
+  padding: 18px;
+
+  [slot="header"] {
+    display: flex;
+    justify-content: space-between;
+    color: $White;
+    margin-bottom: 16px;
+    margin-right: 6px;
+    gap: 6px;
+    div, i {
+      width: -webkit-fill-available;
+    }
+
+    .text {
+      font-weight: bold;
+      font-family: "Aeonik";
+      font-size: 28px;
+      white-space: nowrap;
+      padding-right: 16px;
+    }
+
+    .icon {
+      font-size: 28px;
+      width: 28px;
+      text-align: center;
+    }
+
+    .left {
+      text-align: left;
+    }
+    .right {
+      text-align: right;
+    }
+  }
+
+  .subtitle {
+    color: $Neutral03;
+    font-size: 16px;
+    line-height: 20px;
+    font-weight: 400;
+    font-family: "Inter";
+  }
+
+  &.default, &.success, &.alert, &.warning {
+    border-left-width: 6px;
+    border-right-width: 0;
+    border-left-style: solid;
+  }
+
+  &.success, &.alert, &.warning {
+    [slot="header"]>* {
+      font-size: 18px;
+      line-height: 20px;
+      vertical-align: middle;
+    }
+
+    .text::before {
+      display: inline-block;
+      font-style: normal;
+      font-variant: normal;
+      text-rendering: auto;
+      -webkit-font-smoothing: antialiased;
+      font-family: "Font Awesome 5 Free";
+      font-size: 20px;
+      line-height: inherit;
+      vertical-align: middle;
+      font-weight: 900; 
+      margin-right: 6px;
+    }
+  }
+
+  &.default {
+    border-image: linear-gradient(to bottom, $Primary01, $Secondary02) 1 100%;
+  }
+  &.success {
+    border-image: linear-gradient(to bottom, $Green, $Green) 1 100%;
+    .text::before {
+      content: "\f058";
+      color: $Green;
+    }
+  }
+  &.alert {
+    border-image: linear-gradient(to bottom, $Red, $Red) 1 100%;
+    .text::before {
+      content: "\f071";
+      color: $Red;
+    }
+  }
+  &.warning {
+    border-image: linear-gradient(to bottom, $Orange, $Orange) 1 100%;
+    .text::before {
+      content: "\f05a";
+      color: $Orange;
+    }
+  }
+}

--- a/src/resources/elements/primeDesignSystem/pcard/pcard.scss
+++ b/src/resources/elements/primeDesignSystem/pcard/pcard.scss
@@ -20,9 +20,8 @@
     justify-content: space-between;
     color: $White;
     margin-bottom: 16px;
-    margin-right: 6px;
     gap: 6px;
-    div, i {
+    >span, >div, >i {
       width: -webkit-fill-available;
     }
 
@@ -32,6 +31,7 @@
       font-size: 28px;
       white-space: nowrap;
       padding-right: 16px;
+      width: 100%;
     }
 
     .icon {
@@ -42,6 +42,9 @@
 
     .left {
       text-align: left;
+    }
+    .center {
+      text-align: center;
     }
     .right {
       text-align: right;

--- a/src/resources/elements/primeDesignSystem/pcard/pcard.ts
+++ b/src/resources/elements/primeDesignSystem/pcard/pcard.ts
@@ -1,0 +1,20 @@
+import { bindable } from "aurelia-typed-observable-plugin";
+import { customElement } from "aurelia-framework";
+import "./pcard.scss";
+
+/**
+ * Usage:
+ *    <pcard>Default</pcard>
+ *    <pcard type="success">Success</pcard>
+ *    <pcard type="alert">Alert</pcard>
+ *    <pcard type="warning">Warning</pcard>
+ *    <pcard ... click.delegate="message('Hi!')">Clickable</pcard>
+ *    <pcard ... width="100%">Fix Size</pcard>
+*/
+export type CardType = "default" | "success" | "alert" | "warning" | "";
+
+@customElement("pcard")
+export class PCurd {
+  @bindable.string type: CardType = "";
+  @bindable.string width = "100%";
+}

--- a/src/resources/elements/primeDesignSystem/pcard/pcard.ts
+++ b/src/resources/elements/primeDesignSystem/pcard/pcard.ts
@@ -14,7 +14,7 @@ import "./pcard.scss";
 export type CardType = "default" | "success" | "alert" | "warning" | "";
 
 @customElement("pcard")
-export class PCurd {
+export class PCard {
   @bindable.string type: CardType = "";
   @bindable.string width = "100%";
 }


### PR DESCRIPTION
`pcard` is a reusable component for cards. Can be used for every card element, modals, and/or popups.

Simple:
![image](https://user-images.githubusercontent.com/2517870/147419309-ad40acfd-79c4-4940-b34f-1e681cad0429.png)

Type "default":
![image](https://user-images.githubusercontent.com/2517870/147419334-77678788-5e26-4505-be73-7e0418b6bd1d.png)

Type "Success" | "Warning" | "Alert":
![image](https://user-images.githubusercontent.com/2517870/147419392-6fed7efc-1a8e-4af6-9b4c-e957ce34a8fc.png)

Each card contains 3 optional slots:
`header`, `body`, and/or `footer`.
`header` may contain the folowing elements:
`<span class="text">Header Text</span>` for heading.
`<i class="icon fas fa-times"></i>` for icons.

![image](https://user-images.githubusercontent.com/2517870/147419429-a71c859b-8514-4a3a-9453-f48757b86cea.png)
