### PR TITLE
Updating node engine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "engines": {
-    "node": ">=14.11.0"
+    "node": ">=14.11.0 <15"
   },
   "browser": {
     "http": false


### PR DESCRIPTION
Updating required node version, to be less than 15. Because of issues with used node-sass 4.14 version, it doesn't work wit node 15 or higher https://www.npmjs.com/package/node-sass 