### PR TITLE
Remove unwanted horizontal scrollbar

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -4,7 +4,7 @@
 
 .appWrapper {
   display: grid;
-  grid-template-columns: minmax($BodyPaddingLeftRight, 1fr) 1120px minmax($BodyPaddingLeftRight, 1fr);
+  grid-template-columns:  1fr 1120px 1fr;
   grid-template-rows: 192px 100fr 1fr;
   grid-template-areas:
     ". . ."


### PR DESCRIPTION
Considering how `minmax()` works and the values that were supplied, it was returning value never smaller than 160px. What was causing a horizontal scrollbar, when view port width was smaller that 1440px (160px + 1120px + 160px).
I don't see why we needed that `minmax()` over there as all we wanted was to center the content. `1fr` should be sufficient