### PR TITLE
Chore: Add cypress run command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ node_modules
 /dist
 /public
 /test/coverage-jest
+
+# Cypress
+cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,6 @@
   "pluginsFile": "cypress/plugins/index.js",
   "supportFile": "cypress/support/index.js",
   "testFiles": "**/*.feature",
+  "video": false,
   "experimentalStudio": true
 }

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -32,6 +32,9 @@ Check out few thoughts on Cypress in [Notion](https://www.notion.so/primedao/E2E
 - Open a Cypress GUI, where you can develop interactively
   - Note the "Cypress Studio" feature to generate tests based on your interactions
 
+`npm run e2e-run`
+- Run all cypress tests in headless mode
+
 ### Flow
 1. Single out a Specification, that you want to cover with automated tests
 2. Define the Specifications in [Gherkin][gherkin] format in `.feature` files
@@ -67,5 +70,8 @@ cy.url().should("include", "deals/open");
 
 ### Tooling
 - [VSCode Cucumber Autocomplete Extension](https://github.com/alexkrechik/VSCucumberAutoComplete#settings-example)
+
+### Configuration
+https://docs.cypress.io/guides/references/configuration#cypress-json
 
 [gherkin]: (https://cucumber.io/docs/gherkin/)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "analyze": "cross-env DOTENV_CONFIG_PATH=.env.production webpack --env.production --analyze",
     "test": "au test",
     "e2e": "npx cypress open",
+    "e2e-run": "npx cypress run",
     "lint": "eslint --ext .ts ./src ./test",
     "lint.fix": "npm run lint -- --fix",
     "fetchContracts": "node scripts/fetchContracts.js"


### PR DESCRIPTION
## What was done
1. Add script to run cypress in headless mode: `npm run e2e-run`
2. Disable video (and gitignore)
- if you want to enable videos `npx cypress run -c video=true`
- might want to add this option for CI later

## Testing
`npm run e2e-run`

![image](https://user-images.githubusercontent.com/30693990/149983194-caf74dfc-531d-42e1-9899-e6ac7efe959b.png)
