### PR TITLE
chore(docs): add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## What was done
+
+## Testing
+
+#### Before
+
+#### After


### PR DESCRIPTION
Suggestion to add a template to _all_ PRs.
Note: one can specify multiple PR templates [github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository), but usage is kind of unpractical, because one would need to add a query to the url.

Usage in PR: https://github.com/PrimeDAO/prime-launch-dapp/pull/705

![image](https://user-images.githubusercontent.com/30693990/150235569-e8769491-08f0-4fd4-813d-0232ed042a53.png)
