### PR TITLE
 Add DealsService mock methods and DealEntities

### DIFF
--- a/src/dealWizard/dealWizard.types.ts
+++ b/src/dealWizard/dealWizard.types.ts
@@ -2,8 +2,9 @@ import { IWizard } from "services/WizardService";
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 export interface IProposal {
-  name: string,
-  overview: string,
+  title: string,
+  summary: string,
+  description: string,
 }
 
 export enum Platforms {
@@ -40,9 +41,9 @@ export interface IDAO {
   platform?: Platforms,
 }
 
-export interface IAdmin {
+export interface IProposalLead {
   address: string,
-  represent: IDAO
+  email?: string;
 }
 
 export interface IClause {

--- a/src/entities/Deal.ts
+++ b/src/entities/Deal.ts
@@ -9,6 +9,25 @@ export interface IDealConfiguration {
   beneficiary: Address;
 }
 
+type DealStatus = "hasNotStarted" | "claimingIsOpen" | "incomplete" | "uninitialized" | "contributingIsOpen" | "isPaused" | "isClosed";
+
+export interface IDummyDeal {
+  address: Address,
+  dao: {
+    creator: string,
+    partner?: string,
+  },
+  type: string,
+  title: string,
+  description: string,
+  logo: {
+    creator: string,
+    partner?: string,
+  },
+  startsInMilliseconds: number,
+  status: DealStatus
+}
+
 @autoinject
 export class Deal {
   public contract: any;

--- a/src/entities/MockDealEntity.ts
+++ b/src/entities/MockDealEntity.ts
@@ -1,0 +1,97 @@
+import { IDummyDeal } from "./Deal";
+
+export const OPEN_DEALS_MOCK: IDummyDeal[] = [
+  {
+    address: "0x1jk3lk4353l45kj345l3k45j345",
+    dao: {
+      creator: "DAO Creator 2 With a Looooong Name",
+    },
+    type: "Token Swap",
+    title: "Swap tokenized carbon credits for a better world",
+    description: "Lorem ipsum dolor sit amet, consectetur adi piscing elit. Ut pretium pretium tempor. Uteget imperdiet neque. In volutpat ante semper diam molestie.",
+    logo: {
+      creator: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/primedao.jpg",
+    },
+    status: "contributingIsOpen",
+    startsInMilliseconds: new Date().getUTCMilliseconds() + 0.15 * 1000 * 60 * 60 * 24,
+  },
+  {
+    address: "0x1jk3lk4353l45kj345l3k45j345",
+    dao: {
+      creator: "DAO Creator 1",
+    },
+    type: "Joint Venture",
+    title: "Let’s spice up the world together",
+    description: "Lorem ipsum dolor sit amet, consectetur adi piscing elit. Ut pretium pretium tempor. Uteget imperdiet neque. In volutpat ante semper diam molestie.",
+    logo: {
+      creator: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/primedao.jpg",
+    },
+    status: "hasNotStarted",
+    startsInMilliseconds: new Date().getUTCMilliseconds() + 0.15 * 1000 * 60 * 60 * 24,
+  },
+  {
+    address: "0x1jk3lk4353l45kj345l3k45j345",
+    dao: {
+      creator: "DAO Creator 2 With a Looooong Name",
+    },
+    type: "Token Swap",
+    title: "Proposal Title",
+    description: "Lorem ipsum dolor sit amet, consectetur adi piscing elit. Ut pretium pretium tempor. Uteget imperdiet neque. In volutpat ante semper diam molestie.",
+    logo: {
+      creator: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/primedao.jpg",
+    },
+    status: "claimingIsOpen",
+    startsInMilliseconds: new Date().getUTCMilliseconds() + 0.15 * 1000 * 60 * 60 * 24,
+  },
+];
+
+export const PARTNERED_DEALS_MOCK: IDummyDeal[] = [
+  {
+    address: "0x1jk3lk4353l45kj345l3k45j345",
+    dao: {
+      creator: "DAO Creator 1",
+      partner: "DAO Partner 1",
+    },
+    type: "Joint Venture",
+    title: "Lorem ipsum dolor sit amet, consectetur adipiscing",
+    description: "Lorem ipsum dolor sit amet, consectetur adi piscing elit. Ut pretium pretium tempor. Uteget imperdiet neque. In volutpat ante semper diam molestie.",
+    logo: {
+      creator: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/primedao.jpg",
+      partner: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/uniswap.png",
+    },
+    status: "incomplete",
+    startsInMilliseconds: new Date().getUTCMilliseconds() + 0.15 * 1000 * 60 * 60 * 24,
+  },
+  {
+    address: "0x1jk3lk4353l45kj345l3k45j345",
+    dao: {
+      creator: "DAO Creator 2 With a Looooong Name",
+      partner: "DAO Partner 2",
+    },
+    type: "Token Swap",
+    title: "Proposal Title",
+    description: "Lorem ipsum dolor sit amet, consectetur adi piscing elit. Ut pretium pretium tempor. Uteget imperdiet neque. In volutpat ante semper diam molestie.",
+    logo: {
+      creator: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/primedao.jpg",
+      partner: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/compound.png",
+    },
+    status: "uninitialized",
+    startsInMilliseconds: new Date().getUTCMilliseconds() + 0.15 * 1000 * 60 * 60 * 24,
+  },
+  {
+    address: "0x1jk3lk4353l45kj345l3k45j345",
+    dao: {
+      creator: "DAO Creator 1",
+      partner: "DAO Partner 1",
+    },
+    type: "Joint Venture",
+    title: "Proposal Title",
+    description: "Lorem ipsum dolor sit amet, consectetur adi piscing elit. Ut pretium pretium tempor. Uteget imperdiet neque. In volutpat ante semper diam molestie.",
+    logo: {
+      creator: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/primedao.jpg",
+      partner: "https://deepdao-uploads.s3.us-east-2.amazonaws.com/assets/dao/logo/uniswap.png",
+    },
+    status: "isClosed",
+    startsInMilliseconds: new Date().getUTCMilliseconds() + 0.15 * 1000 * 60 * 60 * 24,
+  },
+];

--- a/src/entities/MockWizardEntity.ts
+++ b/src/entities/MockWizardEntity.ts
@@ -1,0 +1,92 @@
+import { IWizardData } from "services/WizardService";
+
+export const MAKE_OFFER_WIZARD_MOCK: IWizardData = {
+  version: "0.0.1",
+  proposal: {
+    title: "First Proposal",
+    summary: "Lorem ipsum summary",
+    description: "Lorem ipsum description dolor sit amet",
+  },
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  primaryDAO: {
+    id: "",
+    members: [""],
+    name: "Primary DAO",
+    tokens: [{
+      name: "",
+      symbol: "",
+      balance: "",
+      address: "",
+    }],
+    social_medias: [{name: undefined, url: undefined}],
+    logo_url: null,
+  },
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  partnerDAO: {
+    id: "",
+    members: [""],
+    name: "",
+    tokens: [{
+      name: "",
+      symbol: "",
+      balance: "",
+      address: "",
+    }],
+    social_medias: [{name: undefined, url: undefined}],
+    logo_url: null,
+  },
+  proposalLead: {
+    address: "0x123123123",
+    email: "",
+  },
+  isPrivate: true,
+  createdAt: null,
+  modifiedAt: null,
+  createdByAddress: null,
+};
+
+export const OPEN_PROPOSAL_WIZARD_MOCK: IWizardData = {
+  version: "0.0.1",
+  proposal: {
+    title: "",
+    summary: "",
+    description: "",
+  },
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  primaryDAO: {
+    id: "",
+    members: [""],
+    name: "",
+    tokens: [{
+      name: "",
+      symbol: "",
+      balance: "",
+      address: "",
+    }],
+    social_medias: [{name: undefined, url: undefined}],
+    logo_url: null,
+  },
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  partnerDAO: {
+    id: "",
+    members: [""],
+    name: "",
+    tokens: [{
+      name: "",
+      symbol: "",
+      balance: "",
+      address: "",
+    }],
+    social_medias: [{name: undefined, url: undefined}],
+    logo_url: null,
+  },
+  proposalLead: {
+    address: "",
+    email: "",
+  },
+  keepAdminRights: true,
+  offersPrivate: true,
+  createdAt: null,
+  modifiedAt: null,
+  createdByAddress: null,
+};

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -5,6 +5,8 @@ import { autoinject } from "aurelia-framework";
 import { IDealConfig } from "../registry-wizard/dealConfig";
 import { OPEN_DEALS_MOCK, PARTNERED_DEALS_MOCK } from "entities/MockDealEntity";
 import { IDummyDeal } from "entities/Deal";
+import { MAKE_OFFER_WIZARD_MOCK, OPEN_PROPOSAL_WIZARD_MOCK } from "entities/MockWizardEntity";
+import { IWizardData } from "./WizardService";
 
 export interface IDealCreatedEventArgs {
   newDeal: Address;
@@ -80,6 +82,14 @@ export class DealService {
 
   public async getPartneredDeals(): Promise<IDummyDeal[]> {
     return Promise.resolve(PARTNERED_DEALS_MOCK);
+  }
+
+  public async getOpenProposalData(): Promise<IWizardData> {
+    return Promise.resolve(OPEN_PROPOSAL_WIZARD_MOCK);
+  }
+
+  public async getMakeOfferData(): Promise<IWizardData> {
+    return Promise.resolve(MAKE_OFFER_WIZARD_MOCK);
   }
 
   private async getDealsIPFS(): Promise<void> {

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -66,8 +66,8 @@ export class DealService {
     /**
      * deals will take care of themselves on account changes
      */
-    this.getDeals();
-    this.getDAOsInformation();
+    this.getDealsIPFS();
+    // this.getDAOsInformation();
   }
 
   public async getDeals(): Promise<IDummyDeal[]> {
@@ -82,6 +82,7 @@ export class DealService {
     return Promise.resolve(PARTNERED_DEALS_MOCK);
   }
 
+  private async getDealsIPFS(): Promise<void> {
     const hashes = await this.ipfsService.getPinnedObjectsHashes();
     hashes.forEach( async (hash:string) => {
       this.dealsObject[hash] = await (this.ipfsService.getObjectFromHash(hash) as Promise<IDealConfig>)
@@ -125,7 +126,7 @@ export class DealService {
       return await this._featuredDeals;
     }
     else {
-      await this.getDeals();
+      await this.getDealsIPFS();
       /**
        * take the first three deals in order of when they start(ed), if they either haven't
        * started or are live.
@@ -159,7 +160,7 @@ export class DealService {
   }
 
   public async getDAOByOrganisationID(id: string): Promise<IDaoAPIObject> {
-    if (!this.DAOs) await this.getDAOsInformation;
+    // if (!this.DAOs) await this.getDAOsInformation;
 
     const dao: IDaoAPIObject = this.DAOs.filter(dao => dao.organizationId === id)[0];
     return dao;

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -3,6 +3,8 @@ import { IpfsService } from "./IpfsService";
 import { Address } from "./EthereumService";
 import { autoinject } from "aurelia-framework";
 import { IDealConfig } from "../registry-wizard/dealConfig";
+import { OPEN_DEALS_MOCK, PARTNERED_DEALS_MOCK } from "entities/MockDealEntity";
+import { IDummyDeal } from "entities/Deal";
 
 export interface IDealCreatedEventArgs {
   newDeal: Address;
@@ -68,7 +70,18 @@ export class DealService {
     this.getDAOsInformation();
   }
 
-  private async getDeals(): Promise<void> {
+  public async getDeals(): Promise<IDummyDeal[]> {
+    return Promise.resolve(OPEN_DEALS_MOCK);
+  }
+
+  public async getOpenDeals(): Promise<IDummyDeal[]> {
+    return Promise.resolve(OPEN_DEALS_MOCK);
+  }
+
+  public async getPartneredDeals(): Promise<IDummyDeal[]> {
+    return Promise.resolve(PARTNERED_DEALS_MOCK);
+  }
+
     const hashes = await this.ipfsService.getPinnedObjectsHashes();
     hashes.forEach( async (hash:string) => {
       this.dealsObject[hash] = await (this.ipfsService.getObjectFromHash(hash) as Promise<IDealConfig>)

--- a/src/services/WizardService.ts
+++ b/src/services/WizardService.ts
@@ -1,6 +1,7 @@
 import { autoinject } from "aurelia-framework";
 import { Router, RouterConfiguration, NavigationInstruction, RouterEvent } from "aurelia-router";
 import { EventAggregator } from "aurelia-event-aggregator";
+import { IDAO, IProposal, IProposalLead } from "dealWizard/dealWizard.types";
 
 export interface IWizard {
   stages: Array<IWizardStage>;
@@ -19,6 +20,20 @@ export interface IWizardResult {
   version: string;
   clearState: () => void,
   [key: string]: any;
+}
+
+export interface IWizardData {
+  version: string;
+  proposal: IProposal;
+  primaryDAO: IDAO;
+  partnerDAO: IDAO;
+  proposalLead: IProposalLead;
+  isPrivate?: boolean;
+  keepAdminRights?: boolean;
+  offersPrivate?: boolean;
+  createdAt: Date | null;
+  modifiedAt: Date | null;
+  createdByAddress: string | null;
 }
 
 @autoinject


### PR DESCRIPTION
#95
## What was done
This PR is part of #81, and it deals with the Frontend API (CeramicService will come later)

Add
1. DealsService methods
    - 2 methods to get wizard data (cf. #76)
    - 2 methods to get open/partner deals for the home page (cf. #89)
2. DealEntities
    - Stitched together from #76 and #89, will need to align on this
    - cc @paweljanicki and @IonelLupu 
