### PR TITLE
refac(design.input): use @child decorator to get specific slot

### DIFF
--- a/src/resources/elements/primeDesignSystem/pinput-group/pinput-group.html
+++ b/src/resources/elements/primeDesignSystem/pinput-group/pinput-group.html
@@ -1,15 +1,15 @@
 <template class="
-    ${$slots.before.projections ? 'hasBeforeAddon' : ''}
-    ${$slots.after.projections ? 'hasAfterAddon' : ''}
+    ${beforeSlot ? 'hasBeforeAddon' : ''}
+    ${afterSlot ? 'hasAfterAddon' : ''}
   "
 >
-  <div class="addon" show.bind="$slots.before.projections">
+  <div class="addon" show.bind="beforeSlot">
     <slot name="before"></slot>
   </div>
 
   <slot></slot>
 
-  <div class="addon" show.bind="$slots.after.projections">
+  <div class="addon" show.bind="afterSlot">
     <slot name="after"></slot>
   </div>
 

--- a/src/resources/elements/primeDesignSystem/pinput-group/pinput-group.ts
+++ b/src/resources/elements/primeDesignSystem/pinput-group/pinput-group.ts
@@ -1,38 +1,13 @@
-import { customElement } from "aurelia-framework";
+import { customElement, child } from "aurelia-framework";
 import "./pinput-group.scss";
-import { Controller, View } from "aurelia-templating";
-
-interface AureliaSlot {
-  projections: number
-}
-
-type AureliaElement = Element & {
-  au: {
-    controller: Controller & {
-      view: View & {
-        slots: Record<string, AureliaSlot>
-      }
-    }
-  }
-}
 
 @customElement("pinput-group")
 export class PInputGroup {
   element: Element;
-  $slots: Record<string, AureliaSlot>;
+  @child("[slot='before']") beforeSlot;
+  @child("[slot='after']") afterSlot;
 
   constructor(element: Element) {
     this.element = element;
-  }
-
-  attached() {
-    // Unfortunately, Aurelia does not have any official docs on how to get all the used slots in a component,
-    //  so we have to get them using some javascript properties that exist on the element itself.
-    // To make Typescript happy, we had to define our own Element type
-    //  that is not defined in Aurelia's typescript definitions.
-    //  This type correctly defines the existing properties present in HTML elements.
-    const element = this.element as unknown as AureliaElement
-    this.$slots = element.au.controller.view.slots;
-    console.log(this.$slots);
   }
 }


### PR DESCRIPTION
inspiration from `@child` usage in `pform-input` added originally by @IonelLupu 