### PR TITLE
Improve wizardService navigation, add missing wizardTypes, get existing Deal registrationData

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -165,7 +165,7 @@ export class App {
         moduleId: PLATFORM.moduleName("./dealWizard/wizardManager"),
         route: `/initiate/token-swap/partnered-deal/*${STAGE_ROUTE_PARAMETER}`,
         nav: false,
-        name: "partneredDealWizard",
+        name: "createPartneredDeal",
         title: "Create a Partnered Deal",
         settings: {
           wizardType: WizardType.partneredDeal,
@@ -175,10 +175,30 @@ export class App {
         moduleId: PLATFORM.moduleName("./dealWizard/wizardManager"),
         nav: false,
         name: "makeOfferWizard",
-        route: `/make-an-offer/*${STAGE_ROUTE_PARAMETER}`,
-        title: "Submit a Proposal",
+        route: `/make-an-offer/:id/*${STAGE_ROUTE_PARAMETER}`,
+        title: "Make an offer",
         settings: {
           wizardType: WizardType.makeAnOffer,
+        },
+      },
+      {
+        moduleId: PLATFORM.moduleName("./dealWizard/wizardManager"),
+        nav: false,
+        name: "editOpenProposal",
+        route: `/open-proposal/:id/edit/*${STAGE_ROUTE_PARAMETER}`,
+        title: "Edit an Open Proposal",
+        settings: {
+          wizardType: WizardType.openProposalEdit,
+        },
+      },
+      {
+        moduleId: PLATFORM.moduleName("./dealWizard/wizardManager"),
+        nav: false,
+        name: "editPartneredDeal",
+        route: `/partnered-deal/:id/edit/*${STAGE_ROUTE_PARAMETER}`,
+        title: "Edit a Partnered Deal",
+        settings: {
+          wizardType: WizardType.partneredDealEdit,
         },
       },
       {

--- a/src/dealWizard/dealWizardTypes.ts
+++ b/src/dealWizard/dealWizardTypes.ts
@@ -1,6 +1,6 @@
 import { IWizardState } from "services/WizardService";
 
-export enum WizardType {openProposal, partneredDeal, makeAnOffer}
+export enum WizardType {openProposal, openProposalEdit, partneredDeal, partneredDealEdit, makeAnOffer}
 
 export interface IBaseWizardStage {
   wizardManager: any;

--- a/src/services/CeramicServiceMock.ts
+++ b/src/services/CeramicServiceMock.ts
@@ -2,7 +2,7 @@ import { DealRegistrationData, IDAO } from "entities/DealRegistrationData";
 import { IDataSourceDeals, IKey } from "services/DataSourceDealsTypes";
 
 const MOCK_DATA = {
-  "root_stream_id": ["open_deals_stream_id", "partner_deals_stream_id"],
+  "root_stream_id": ["open_deals_stream_id", "partner_deals_stream_id", "open_deals_stream_id_2"],
   "open_deals_stream_id": {
     registration: {
       daos: [
@@ -11,7 +11,18 @@ const MOCK_DATA = {
     },
   },
   "open_deals_stream_id_2": {
-    registration: new DealRegistrationData(),
+    registration: {
+      ...new DealRegistrationData(),
+      proposal: {
+        title: "First Proposal",
+        summary: "Quick summary",
+        description: "Long description lorem ipsum",
+      },
+      proposalLead: {
+        address: "0x123123123",
+        email: "",
+      },
+    },
   },
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   "partner_deals_stream_id": {

--- a/src/services/WizardService.ts
+++ b/src/services/WizardService.ts
@@ -1,5 +1,6 @@
 import { autoinject } from "aurelia-framework";
 import { Router } from "aurelia-router";
+import { STAGE_ROUTE_PARAMETER } from "dealWizard/dealWizardTypes";
 
 export interface IWizardState<Data = any> {
   stages: Array<IWizardStage>;
@@ -100,7 +101,16 @@ export class WizardService {
   public goToStage(wizardManager: any, index: number): void {
     const wizardState = this.getWizardState(wizardManager);
     wizardState.indexOfActive = index;
-    this.router.navigate(wizardState.stages[index].route);
+
+    const params = {
+      ...this.router.currentInstruction.params,
+      [STAGE_ROUTE_PARAMETER]: wizardState.stages[index].route,
+    };
+
+    this.router.navigateToRoute(
+      this.router.currentInstruction.config.name,
+      params,
+    );
   }
   public hasWizard(wizardManager: any): boolean {
     return this.wizardsStates.has(wizardManager);


### PR DESCRIPTION
## What was done
- Update `goToStage` method in `wizardService` to navigate based on route name and params
- Add `openProposalEdit` and `partneredDealEdit` wizardTypes
- In wizardManager get deal by id from URL param (if exists)

## Testing
- Create Partnered Deal https://prime-deals-dapp-git-use-deal-service-in-wizar-369421-curvelabs.vercel.app/initiate/token-swap/partnered-deal/proposal
- Edit Partnered Deal https://prime-deals-dapp-git-use-deal-service-in-wizar-369421-curvelabs.vercel.app/partnered-deal/open_deals_stream_id_2/edit/proposal
- Create Open Proposal https://prime-deals-dapp-git-use-deal-service-in-wizar-369421-curvelabs.vercel.app/initiate/token-swap/open-proposal/proposal
- Edit Open Proposal https://prime-deals-dapp-git-use-deal-service-in-wizar-369421-curvelabs.vercel.app/open-proposal/open_deals_stream_id_2/edit/proposal
- Make an offer https://prime-deals-dapp-git-use-deal-service-in-wizar-369421-curvelabs.vercel.app/make-an-offer/open_deals_stream_id_2/proposal
