### PR TITLE
Chore: add wallaby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23444,6 +23444,28 @@
         "makeerror": "1.0.x"
       }
     },
+    "wallaby-webpack": {
+      "version": "3.9.16",
+      "resolved": "https://registry.npmjs.org/wallaby-webpack/-/wallaby-webpack-3.9.16.tgz",
+      "integrity": "sha512-z252lpX5+SrE3DM/YM1XKqJNsYjO5Sd9ATPe9MZCvPHDJZk015OVkBbJqBlcTwOjSS3WCrMQzm6t9tgFnNYHIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.3",
+        "lodash": "^4.17.10",
+        "minimatch": "3.0.3"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        }
+      }
+    },
     "watchpack": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "ts-loader": "^8.0.4",
     "typescript": "^4.0.3",
     "url-loader": "^4.1.0",
+    "wallaby-webpack": "^3.9.16",
     "webpack": "^4.44.2",
     "webpack-bundle-analyzer": "^3.9.0",
     "webpack-cli": "^3.3.12",

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,96 @@
+const path = require("path");
+let wallabyWebpack = require("wallaby-webpack");
+let AureliaPlugin = require("aurelia-webpack-plugin").AureliaPlugin;
+let DefinePlugin = require("webpack").DefinePlugin;
+let webpack = require("webpack");
+
+module.exports = function(wallaby) {
+  let wallabyPostprocessor = wallabyWebpack({
+    resolve: {
+      modules: [
+        path.join(wallaby.projectCacheDir, "src"),
+        path.join(__dirname, "node_modules"),
+        path.join(__dirname, "../../node_modules")
+      ]
+    },
+    "node": {
+      "fs": "empty"
+    },
+
+    module: {
+      rules: [{
+        test: /\.html$/i,
+        loader: "html-loader"
+      },
+      {
+        test: /\.png$|\.gif$|\.svg$|\.jpe?g$/,
+        loaders: "null"
+      },
+      {
+        test: /\.css$/i,
+        issuer: [{
+          not: [{
+            test: /\.html$/i
+          }]
+        }],
+        use: ["style-loader", "css-loader"]
+      },
+      {
+        test: /\.css$/i,
+        issuer: [{
+          test: /\.html$/i
+        }],
+        use: "css-loader"
+      }
+      ]
+    },
+
+    plugins: [
+      new DefinePlugin({
+        AURELIA_WEBPACK_2_0: undefined
+      }),
+      new AureliaPlugin({
+        aureliaApp: undefined,
+        viewsFor: "{" + path.relative(path.resolve(), wallaby.projectCacheDir) + "/,}**/!(tslib)*.{ts,js}"
+      }),
+      new webpack.NormalModuleReplacementPlugin(/\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico||scss|css)$/, "node-noop"),
+      new webpack.ProvidePlugin({})
+    ]
+  });
+
+  return {
+    files: [
+      {
+        pattern: "src/**/*.+(ts|html|json)",
+        load: false
+      },
+    ],
+
+
+    tests: [
+      "test/unit/entities/Deal.spec.ts"
+      // { pattern: "test/unit/**/*.spec.ts", load: false },
+      // { pattern: "test/unit/**/abstract-mode.spec.ts", load: false }
+      // { pattern: "test/unit/**/Deal.spec.ts", load: false }
+      // { pattern: "test/unit/**/vim.spec.ts", load: false }
+    ],
+
+    compilers: {
+      "**/*.ts": wallaby.compilers.typeScript({
+        module: "commonjs"
+      })
+    },
+
+    env: {
+      kind: "chrome"
+    },
+
+    postprocessor: wallabyPostprocessor,
+
+    setup: function() {
+      window.__moduleBundler.loadTests();
+    },
+
+    debug: true
+  };
+};


### PR DESCRIPTION
## What was done
Add Wallaby
  ![image](https://user-images.githubusercontent.com/30693990/151626498-0d0b7419-0a30-4d3c-b74f-f22e504a252e.png)

## Usage
(instructions will only be given for VSCode, for [Jetbrains, please consult the docs](https://wallabyjs.com/docs/intro/get-started-jetbrains.html))
1. Download extension for VSCode `wallabyjs.wallaby-vscode`
2. (buy licence) - (could test for free as well)
3. Create a unit test file
4. Command: Wallaby Start
5. Observe the magic