### PR TITLE
Fix/162 private button default off

### DIFF
--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -65,3 +65,16 @@ Then("I am presented with the {string} error message for the {string} field", (m
     cy.get(".errorMessage").should("contain.text", message);
   });
 });
+
+
+When("I'm in the {string} section", (sectionHeading: string) => {
+  cy.contains(".stageSectionSidebar .heading.title", sectionHeading)
+   .should("be.visible")
+})
+
+Then("the {string} option should be turned off", (optionText: string) => {
+  cy.get(`pform-input[label='${optionText}']`).within(formComponent => {
+    cy.contains(optionText).should("be.visible")
+    cy.get("[data-test='pToggleInput']").invoke("val").should("equal", "false")
+  })
+})

--- a/cypress/integration/features/deals/open-proposal/stage2.feature
+++ b/cypress/integration/features/deals/open-proposal/stage2.feature
@@ -24,3 +24,7 @@ Feature: "Lead details" stage (Stage 2)
     When I fill in the 'Wallet address' field with '0x0DA7fB6eeDdBcc5A5EBe388783aD5cA99a556677'
     And I try to proceed to next step
     Then I am presented with the 'Open proposal' 'Primary DAO' stage
+
+  Scenario: Private Offers option should be turned off by default
+    When I'm in the "Make Offers Private?" section
+    Then the "Make Offers Private" option should be turned off

--- a/cypress/integration/features/deals/partnered-deal/stage2.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage2.feature
@@ -24,3 +24,8 @@ Feature: "Lead details" stage (Stage 2)
     When I fill in the 'Wallet address' field with '0x0DA7fB6eeDdBcc5A5EBe388783aD5cA99a556677'
     And I try to proceed to next step
     Then I am presented with the 'Partnered Deal' 'Primary DAO' stage
+
+  Scenario: Private Deal option should be turned off by default
+    When I'm in the "Make Deal Private?" section
+    Then the "Make Deal Private" option should be turned off
+

--- a/src/entities/DealRegistrationTokenSwap.ts
+++ b/src/entities/DealRegistrationTokenSwap.ts
@@ -131,7 +131,7 @@ export class DealRegistrationTokenSwap implements IDealRegistrationTokenSwap {
     };
     this.keepAdminRights = true;
     this.offersPrivate = true;
-    this.isPrivate = true;
+    this.isPrivate = false;
     this.createdAt = null;
     this.modifiedAt = null;
     this.createdByAddress = null;

--- a/src/entities/DealRegistrationTokenSwap.ts
+++ b/src/entities/DealRegistrationTokenSwap.ts
@@ -130,7 +130,7 @@ export class DealRegistrationTokenSwap implements IDealRegistrationTokenSwap {
       email: "",
     };
     this.keepAdminRights = true;
-    this.offersPrivate = true;
+    this.offersPrivate = false;
     this.isPrivate = false;
     this.createdAt = null;
     this.modifiedAt = null;

--- a/src/resources/elements/primeDesignSystem/ptoggle/ptoggle.html
+++ b/src/resources/elements/primeDesignSystem/ptoggle/ptoggle.html
@@ -1,7 +1,9 @@
 <template class="pInput-parent ${ validationState ? 'pInput-parent-' + validationState : '' }">
   <label class="pToggle">
     <input
+      data-test="pToggleInput"
       checked.bind="value"
+      value.bind="value"
       class="pToggleInput ${ validationState ? 'pInput-' + validationState : '' }"
       disabled.bind="disabled"
       type="checkbox"

--- a/src/resources/elements/primeDesignSystem/ptoggle/ptoggle.scss
+++ b/src/resources/elements/primeDesignSystem/ptoggle/ptoggle.scss
@@ -8,7 +8,10 @@
   transition: .4s;
 
   .pToggleInput {
-    display: none;
+    display: inline;
+    opacity: 0;
+    height: 0;
+    width: 0;
   }
 
   .pToggleSlider {
@@ -36,7 +39,8 @@
     border-radius: 50%;
   }
 
-  .checkedIcon, .uncheckedIcon {
+  .checkedIcon,
+  .uncheckedIcon {
     transition: .4s;
     color: $BG01;
   }
@@ -46,7 +50,7 @@
   }
 
   .pToggleInput:checked {
-    + .pToggleSlider {
+    +.pToggleSlider {
       background: $Gradient01;
 
       .checkedIcon {
@@ -59,13 +63,13 @@
     }
   }
 
-  .pToggleInput:checked + .pToggleSlider:before {
+  .pToggleInput:checked+.pToggleSlider:before {
     transform: translateX(calc(100% + 2px));
   }
 
   .pToggleInput:disabled {
 
-    + .pToggleSlider {
+    +.pToggleSlider {
       cursor: not-allowed;
       background: transparent;
       border: 1px solid $Neutral02;
@@ -74,7 +78,8 @@
         background-color: $Neutral02;
       }
 
-      .checkedIcon, .uncheckedIcon {
+      .checkedIcon,
+      .uncheckedIcon {
         color: $Neutral02;
       }
     }

--- a/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
@@ -80,7 +80,7 @@
         <pform-input
           class="wizardFormInput"
           label="Make Offers Private">
-          <ptoggle value.bind="wizardState.registrationData.offersPrivate"></ptoggle>
+          <ptoggle value.bind="wizardState.registrationData.offersPrivate || false"></ptoggle>
         </pform-input>
       </div>
     </div>

--- a/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
@@ -98,7 +98,7 @@
           label="Make Deal Private">
           <ptoggle
             disabled.bind="isMakeAnOfferWizardAndKeepsAdminRights"
-            value.bind="wizardState.registrationData.isPrivate"
+            value.bind="wizardState.registrationData.isPrivate || false"
           ></ptoggle>
         </pform-input>
       </div>

--- a/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
@@ -80,7 +80,7 @@
         <pform-input
           class="wizardFormInput"
           label="Make Offers Private">
-          <ptoggle value.bind="wizardState.registrationData.offersPrivate || false"></ptoggle>
+          <ptoggle value.bind="wizardState.registrationData.offersPrivate"></ptoggle>
         </pform-input>
       </div>
     </div>
@@ -98,7 +98,7 @@
           label="Make Deal Private">
           <ptoggle
             disabled.bind="isMakeAnOfferWizardAndKeepsAdminRights"
-            value.bind="wizardState.registrationData.isPrivate || false"
+            value.bind="wizardState.registrationData.isPrivate"
           ></ptoggle>
         </pform-input>
       </div>


### PR DESCRIPTION
#162 

## What was done
- change mock data to `false`
- default binding in the view to `|| false` as well
- add e2e tests

## Testing
Navigate to 
- http://localhost:3340/initiate/token-swap/partnered-deal/lead-details
- http://localhost:3340/initiate/token-swap/open-proposal/lead-details

#### Before
- privacy option was true

#### After
- privacy option is _now false_