### PR TITLE
Width should apply the same declaration

### DIFF
--- a/src/resources/elements/dealSummary/dealSummary.scss
+++ b/src/resources/elements/dealSummary/dealSummary.scss
@@ -2,7 +2,7 @@
 @import "../primeDesignSystem/variables";
 
 deal-summary {
-  pcard {
+  .pcard {
     display: inline-block;
     width: 360px;
     background-color: $BG02;


### PR DESCRIPTION
## What was done
Small fix to the deal summary component. Width should be fixed 360px.

#### Before
Fix width didn't apply to the `dealSummary` component, due to a change in the `pCard` component.

#### After
`dealSummary` CSS declaration is pointing to the class name instead of the element, overwriting the original width behavior of `pCard`.