### PR TITLE
Refactor/pcard custom gradient bg

### DIFF
--- a/src/resources/elements/primeDesignSystem/_styles.scss
+++ b/src/resources/elements/primeDesignSystem/_styles.scss
@@ -1,7 +1,7 @@
 @import "./pinput";
 @import "./typography";
 
-@mixin pcardBgAndGradient($backgroundColor: $BG02, $grColor01: $Primary01, $grColor02: $Primary02) {
+@mixin pcardBgAndGradient($backgroundColor: $BG02, $grColor01: $Primary01, $grColor02: $Secondary02) {
   background: /* this is the card background: */
     linear-gradient($backgroundColor, $backgroundColor) padding-box,
     /* this is the gradient on the left side: */

--- a/src/resources/elements/primeDesignSystem/_styles.scss
+++ b/src/resources/elements/primeDesignSystem/_styles.scss
@@ -1,6 +1,15 @@
 @import "./pinput";
 @import "./typography";
 
+@mixin pcardBgAndGradient($backgroundColor: $BG02, $grColor01: $Primary01, $grColor02: $Primary02) {
+  background: /* this is the card background: */
+    linear-gradient($backgroundColor, $backgroundColor) padding-box,
+    /* this is the gradient on the left side: */
+    linear-gradient(to bottom, $grColor01, $grColor02) border-box;
+  border-left: $border-radius-small solid transparent;
+  border-right: $border-radius-small solid $backgroundColor;
+}
+
 .pcard {
   padding: $spacing-normal; // only if there is no padding on the parent
   border-radius: $border-radius-small;
@@ -9,11 +18,6 @@
   width: inherit;
 
   &.gradient {
-    background: /* this is the card background: */
-      linear-gradient($BG02, $BG02) padding-box,
-      /* this is the gradient on the left side: */
-      linear-gradient(to bottom, $Primary01, $Secondary02) border-box;
-    border-left: $border-radius-small solid transparent;
-    border-right: $border-radius-small solid $BG02;
+    @include pcardBgAndGradient();
   }
 }

--- a/src/resources/elements/primeDesignSystem/demos/pcardDemo.html
+++ b/src/resources/elements/primeDesignSystem/demos/pcardDemo.html
@@ -46,9 +46,41 @@
 
     <h2>Gradient Card</h2>
     <p>
-      Optional: <code>type="gradient"</code> to provide gradient left border.
+      Optional: <code>type="gradient"</code>/<code>class="... gradient"</code> to provide gradient left border.
     </p>
     <pcard class="card4" type="gradient">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </pcard>
+
+    <h2>Custom Background for Gradient Card</h2>
+    <p>
+      Overriding the default card background color or the gradient border color.
+    </p>
+    <h3>Syntax</h3>
+    <code>
+      &.gradient {<br>
+      &ensp;@include pcardBgAndGradient($backgroundColor, $grColor01, $grColor02);<br>
+      }
+    </code>
+
+    <h3>Example 1</h3>
+    <code>
+      &.gradient {<br>
+      &ensp;@include pcardBgAndGradient($backgroundColor: $Neutral02);<br>
+      &ensp;color: black;<br>
+      }
+    </code>
+    <pcard class="card5" type="gradient">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </pcard>
+
+    <h3>Example 2</h3>
+    <code>
+      &.gradient {<br>
+      &ensp;@include pcardBgAndGradient($grColor01: $Green, $grColor02: $Red);<br>
+      }
+    </code>
+    <pcard class="card6" type="gradient">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     </pcard>
   </section>

--- a/src/resources/elements/primeDesignSystem/demos/pcardDemo.scss
+++ b/src/resources/elements/primeDesignSystem/demos/pcardDemo.scss
@@ -32,8 +32,9 @@
   }
 
   code {
-    background-color: $Neutral02;
-    padding: 2px;
+    background-color: $BG03;
+    padding: 1px $spacing-small;
+    color: $Orange;
     border-radius: $border-radius-small;
   }
 
@@ -47,5 +48,17 @@
 
   .card4 {
     height: 75px;
+  }
+
+  .card5 {
+    &.gradient {
+      @include pcardBgAndGradient($backgroundColor: $Neutral02);
+      color: black;
+    }
+  }
+  .card6 {
+    &.gradient {
+      @include pcardBgAndGradient($grColor01: $Green, $grColor02: $Red);
+    }
   }
 }

--- a/src/resources/elements/primeDesignSystem/pcard/pcard.ts
+++ b/src/resources/elements/primeDesignSystem/pcard/pcard.ts
@@ -5,11 +5,27 @@ import "../_styles.scss";
 /**
  * Usage:
  *    <pcard>Default</pcard>
- *    <pcard type="success">Success</pcard>
- *    <pcard type="alert">Alert</pcard>
- *    <pcard type="warning">Warning</pcard>
+ *    <pcard type="gradient">Gradient left border</pcard>
  *    <pcard ... click.delegate="message('Hi!')">Clickable</pcard>
  *    <pcard ... width="100%">Fix Size</pcard>
+ *
+ *    <div class="pcard">As a div</div>
+ *    <div class="pcard gradient">As a div with gradient border</div>
+ *
+ * Options:
+ *  type: "gradient" (optional)
+ *
+ *  Override background color on a gradient pcard:
+ *  use:
+ *  ```scss
+ *  &.gradient {
+ *    @include pcardBgAndGradient($backgroundColor, $grColor01, $grColor02);
+ *  }
+ * ```
+ * Defaults:
+ * $backgroundColor: $BG02
+ * $grColor01: $Primary01
+ * $grColor02: $Secondary02
 */
 export type CardType = "gradient" | "";
 


### PR DESCRIPTION
## What was done
A small refactor to <pcard>.
Now, a custom background color or gradient color can override the default.
 
## How to use
Syntax:
```scss
.pcard.gradient{
  @include pcardBgAndGradient($backgroundColor, $grColor01, $grColor02);
}
```
Defaults:
$backgroundColor: $BG02
$grColor01: $Primary01
$grColor02: $Secondary02

### Examples
```scss
.pcard.gradient{
  @include pcardBgAndGradient($Neutral01);
}
```
Result:
![image](https://user-images.githubusercontent.com/2517870/154834270-beabf72a-11ef-4823-a914-8852ff837a58.png)

or
```scss
.pcard.gradient{
  @include pcardBgAndGradient($Orange, $Green, $Green);
}
```
Result:
![image](https://user-images.githubusercontent.com/2517870/154834329-ac8672f1-0768-4c1e-9e1b-c598c4635d86.png)

or
```scss
.pcard.gradient{
  @include pcardBgAndGradient($grColor01: $Green, $grColor02: $Red);
}
```
Result:
![image](https://user-images.githubusercontent.com/2517870/154834406-d30e4f37-7abc-4a25-a755-a0ac7f65675d.png)
