### PR TITLE
fix(demo): remove all: unset 

### DIFF
--- a/src/resources/elements/primeDesignSystem/demos/pselectDemo.scss
+++ b/src/resources/elements/primeDesignSystem/demos/pselectDemo.scss
@@ -5,7 +5,6 @@ pselect {
 
 .demo {
   h1, h2, p {
-    all: unset;
     display: block;
     padding-top: 5px;
   }


### PR DESCRIPTION
reason: gets bundled and overwrites other css (eg. stacks.min.css)

## What was done

## Testing
```
### Make sure confetti disappears when commented out
1. comment out the stacks.min.css import
2. npm run build-dev
3. npm run serve

### Test, that confetti appears when imported
1. Normal import of stacks.min.css
2. npm run build-dev
3. npm run serve
```

Other notes:
```
Re: CSS "leaking" in production

@dkent and I just encountered a small but annoying css bug:
Prod builds did not show the confetti in the demo page

Reason: Prod bundles all the css.
For the problem above, that meant a css style from another demo `all: unset` got "leaked"
into the popup page, thus overwriting the animation
```