### PR TITLE
fixed pselect behavior when used with and empty string instead of undefined

### DIFF
--- a/src/resources/elements/primeDesignSystem/pform-input/pform-input.ts
+++ b/src/resources/elements/primeDesignSystem/pform-input/pform-input.ts
@@ -3,7 +3,6 @@ import "./pform-input.scss";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { ValidationState } from "../types";
 import { Disposable } from "aurelia-binding";
-import tippy from "tippy.js";
 import { AureliaHelperService } from "../../../../services/AureliaHelperService";
 
 @customElement("pform-input")
@@ -15,7 +14,7 @@ export class PFormInput {
   @bindable.number maxLength = 0;
   @bindable.string helperMessage = "";
   @bindable validationMessage = "";
-  @bindable.string validationState?: ValidationState;
+  @bindable validationState?: ValidationState;
 
   /*
   * By default, "pform-input" will select its first child as the "input" property.
@@ -35,7 +34,6 @@ export class PFormInput {
    */
   @child("*") input;
 
-  private labelInfoIcon: HTMLElement;
   private inputValueObserverSubscription?: Disposable;
 
   constructor(
@@ -46,10 +44,6 @@ export class PFormInput {
 
   attached() {
     this.inputReference = this.inputReference ?? this.input;
-
-    if (this.labelInfoIcon) {
-      tippy(this.labelInfoIcon);
-    }
 
     this.validationStateChanged(this.validationState);
 

--- a/src/resources/elements/primeDesignSystem/pselect/pselect.ts
+++ b/src/resources/elements/primeDesignSystem/pselect/pselect.ts
@@ -62,7 +62,9 @@ export class PSelect {
         {text: this.placeholder, placeholder: true, value: null},
         ...this.data ?? [],
       ],
-      onChange: info => this.value = Array.isArray(info) ? info.map(item => item.value) : info.value,
+      onChange: info => {
+        this.value = Array.isArray(info) ? info.map(item => item.value) : (info.value ?? this.value);
+      },
     });
     this.select.set(this.value);
   }


### PR DESCRIPTION
## What was done
fixed the issue where the pselect was marked with an error when used with an empty string value inside a pform-input