### PR TITLE
changed terms clause error message

### DIFF
--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.ts
@@ -26,6 +26,7 @@ export class TermClause {
     const rules = ValidationRules
       .ensure<IClause, string>(clause => clause.text)
       .required()
+      .withMessage("Clause requires a description")
       .rules;
 
     this.form.addObject(this.clause, rules);


### PR DESCRIPTION
## What was done
Changed terms clause error message
#### Before
The error message was "Text is required"

#### After
The error message is "Clause requires a description"