### PR TITLE
e2e(discussion): fix invalid dealId

### DIFF
--- a/cypress/integration/tests/dealDashboard/no-discussions-in-list.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/no-discussions-in-list.e2e.ts
@@ -1,7 +1,8 @@
 import { Given, Then } from "@badeball/cypress-cucumber-preprocessor/methods";
 
 Given("I navigate to a Deal Dashboard", () => {
-  cy.visit("/deal/0x0");
+  const dealId = "open_deals_stream_hash_3";
+  cy.visit(`/deal/${dealId}`);
 });
 Given("No thread is created for this deal", () => {
   cy.contains(".header", "Discuss");


### PR DESCRIPTION
`0x0` dealId probably came from local development