### PR TITLE
Fix/wizard style tweaks

### DIFF
--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -79,6 +79,10 @@
 
         > .selector-tab {
           cursor: pointer;
+
+          &:hover:not(.active) {
+            -webkit-text-fill-color: $Neutral04;
+          }
         }
 
         display: flex;

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -1,10 +1,6 @@
 @import "src/styles/styles.scss";
 @import "../resources/elements/primeDesignSystem/variables";
-
-@mixin border-gradient($borderGradientColor) {
-  border-image-slice: 1;
-  border-image-source: $borderGradientColor;
-}
+@import "../resources/elements/primeDesignSystem/colors";
 
 .page.home {
   .section {

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -1,6 +1,11 @@
 @import "src/styles/styles.scss";
 @import "../resources/elements/primeDesignSystem/variables";
 
+@mixin border-gradient($borderGradientColor) {
+  border-image-slice: 1;
+  border-image-source: $borderGradientColor;
+}
+
 .page.home {
   .section {
     &.hero,
@@ -87,7 +92,8 @@
           -webkit-text-fill-color: transparent;
           -webkit-background-clip: text;
           background-clip: text;
-          border-bottom: 6px solid $Secondary02;
+          border-bottom: 6px solid;
+          @include border-gradient($Gradient02);
           padding-bottom: 19px;
         }
 

--- a/src/resources/elements/primeDesignSystem/_colors.scss
+++ b/src/resources/elements/primeDesignSystem/_colors.scss
@@ -47,6 +47,11 @@ $Gradient09: linear-gradient(220.2deg, #a258a7 0%, #ff497a 100%);
   -webkit-text-fill-color: transparent;
 }
 
+@mixin border-gradient($borderGradientColor) {
+  border-image-slice: 1;
+  border-image-source: $borderGradientColor;
+}
+
 $Red: #ff5252; // Fail
 $Red-BG: #3e263c;
 $Orange: #ffb155; // Warning

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -30,6 +30,13 @@ $font-size1: 14px;
 $font-size2: 16px;
 $font-size3: 18px;
 
+$sub-heading: Inter;
+$heading: Aeonik;
+
+@mixin subHeading() {
+  font-family: $sub-heading;
+}
+
 @mixin spin {
   @keyframes spin {
     from {
@@ -42,7 +49,8 @@ $font-size3: 18px;
 }
 
 @mixin loading-icon {
-  .loading > i,
+
+  .loading>i,
   i.loading {
     animation-name: spin;
     animation-duration: 1.5s;

--- a/src/resources/elements/primeDesignSystem/pform-input/pform-input.scss
+++ b/src/resources/elements/primeDesignSystem/pform-input/pform-input.scss
@@ -1,4 +1,5 @@
 @import "../styles";
+@import "../variables";
 
 $pformInputLineHeight: 33px;
 
@@ -12,6 +13,7 @@ pform-input {
     justify-content: space-between;
 
     .formInputLabelTitle {
+      @include subHeading;
       font-size: $font-size3;
       font-weight: 700;
       line-height: $pformInputLineHeight;

--- a/src/resources/elements/primeDesignSystem/pstepper/pstepper.scss
+++ b/src/resources/elements/primeDesignSystem/pstepper/pstepper.scss
@@ -12,6 +12,10 @@
 
   .active {
     color: $Secondary02;
+
+    .valid {
+      color: $Secondary02;
+    }
   }
   .valid {
     color: $Neutral02;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,5 +1,6 @@
 @import "./animations";
 @import "../resources/elements/primeDesignSystem/styles";
+@import "../resources/elements/primeDesignSystem/variables";
 @import "../resources/elements/primeDesignSystem/colors";
 @import "./colors";
 @import "tippy.js/dist/tippy.css"; // TODO: use CDN?
@@ -109,6 +110,7 @@ html {
         margin-bottom: 8px;
       }
       &.heading3 {
+        @include subHeading;
         font-size: 26px;
         line-height: 24px;
         margin-bottom: 6px;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -102,7 +102,6 @@ html {
       &.heading1 {
         font-size: 48px;
         line-height: 46px;
-        padding-bottom: 24px;
       }
       &.heading2 {
         font-size: 36px;

--- a/src/wizards/tokenSwapDealWizard/components/daoStageContent/daoStageContent.scss
+++ b/src/wizards/tokenSwapDealWizard/components/daoStageContent/daoStageContent.scss
@@ -1,4 +1,5 @@
 @import "styles/styles.scss";
+@import "resources/elements/primeDesignSystem/variables";
 
 dao-stage-content {
   .daoRepresentative, .daoSocialMedia {
@@ -21,6 +22,7 @@ dao-stage-content {
   .multiFieldTitle {
     color: $Secondary02;
     margin-bottom: $spacing-normal;
+    @include subHeading;
     font-size: $font-size3;
     font-weight: 700;
   }


### PR DESCRIPTION
## What was done
Address multiple wizard style tweaks
- heading 
   - font-family
   - margins
- various colors

---

- 248 Match colors of validated Circles and the title underneath the Step Progress Bar
[fix(stepper): valid and active color](https://github.com/PrimeDAO/prime-deals-dapp/pull/276/commits/230c7f214133e20016ace2dc9c8bece1dd1d616d)

- 249 Registration wizard style tweaks
[styles(*): Inter for subheadings / titles](https://github.com/PrimeDAO/prime-deals-dapp/pull/276/commits/c0d2d1d6bd2380d4e37d9a98570d4d80e9ee3523)
[styles(h1): remove padding](https://github.com/PrimeDAO/prime-deals-dapp/pull/276/commits/6f0cdd6b12a3e7d09868107d28077f499657ea35)

- 258 Open Proposals and Partnered Deals Titles needs adjustments
[styles(home): fix deal types headings bottom border color](https://github.com/PrimeDAO/prime-deals-dapp/pull/276/commits/fbdcacac3da631be843fb9ac6b0ddfca08801d63)
[styles(home): fix hover color](https://github.com/PrimeDAO/prime-deals-dapp/pull/276/commits/8db341beebc97c7882f0d6bb0cf97c2ab30d34e3)


## Testing
See connected issues