### PR TITLE
Fix/discussions ens and route

### DIFF
--- a/src/dealDashboard/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/discussionThread/discussionThread.ts
@@ -91,7 +91,13 @@ export class DiscussionThread {
     document.removeEventListener("scroll", this.scrollEvent);
   }
 
-  private async initialize(): Promise<void> {
+  discussionIdChanged() {
+    if (this.deal) {
+      this.initialize(true);
+    }
+  }
+
+  private async initialize(isIdChange = false): Promise<void> {
     this.isLoading.discussions = true;
 
     this.isAuthorized = this.checkIsAuthorized;
@@ -117,7 +123,11 @@ export class DiscussionThread {
       this.dealDiscussion = await this.discussionsService.discussions[this.discussionId];
 
       // Ensures comment fetching and subscription
-      this.ensureDealDiscussion(this.discussionId);
+      await this.ensureDealDiscussion(this.discussionId);
+      if (this.discussionId && this.isInView(this.refThread) && !isIdChange) {
+        this.discussionsService.autoScrollAfter(0);
+      }
+
     } else {
       this.isLoading.discussions = false;
     }
@@ -218,10 +228,6 @@ export class DiscussionThread {
           }
         }
       });
-
-      if (this.isInView(this.refThread)) {
-        this.discussionsService.autoScrollAfter(0);
-      }
 
       // Update the discussion status
       this.discussionsService.updateDiscussionListStatus(discussionId);

--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -298,6 +298,7 @@ export class DiscussionsService {
             comment.text = text;
           });
         }
+        if (comment.authorENS) comment.authorName = comment.authorENS;
       });
 
       latestTimestamp = latestTimestamp ? (latestTimestamp / 1000000) : new Date().getTime();


### PR DESCRIPTION
## What was done
1. ENS names for comments are taken directly from the comments object returned from `theconvo.space` API. For other cases (such as the discussion header) - imported using ethers.js.

2. Fixed an issue when switching between two discussions from the clause list (pressing the 'discuss' button on a clause)
