### PR TITLE
Revert removal of padding in stages header

### DIFF
--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -1,0 +1,3 @@
+h1 {
+  margin: unset;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,4 +1,5 @@
 @import "./animations";
+@import "./reset";
 @import "../resources/elements/primeDesignSystem/styles";
 @import "../resources/elements/primeDesignSystem/variables";
 @import "../resources/elements/primeDesignSystem/colors";
@@ -102,6 +103,7 @@ html {
       &.heading1 {
         font-size: 48px;
         line-height: 46px;
+        padding-bottom: 24px;
       }
       &.heading2 {
         font-size: 36px;

--- a/src/wizards/tokenSwapDealWizard/components/stageWrapper/stageWrapper.scss
+++ b/src/wizards/tokenSwapDealWizard/components/stageWrapper/stageWrapper.scss
@@ -7,7 +7,7 @@
 
   .stageHeader {
     margin-top: 60px;
-    margin-bottom: 32px;
+    margin-bottom: 8px;
   }
 
   .stageSection {


### PR DESCRIPTION
## What was done
- use another approach to fix https://github.com/primedao/prime-deals-dapp/issues/249
  - that is, remove the margin of the parent element

- thus reduce changes to other places

## Testing
1. original issue in 249
![image](https://user-images.githubusercontent.com/30693990/157101629-13546dfd-f4fd-42d0-afba-08f36ef88855.png)


2. discovered by gilad in initialize phase
`http://localhost:3340/initiate/token-swap`
![image](https://user-images.githubusercontent.com/30693990/157101653-a3e3f015-f652-4042-ba73-b22e11bc1b75.png)


#### Before
- 2. was cut-off

#### After
- 1. and 2. as expected