### PR TITLE
fix(wizard): set default address for "Connect to submit" to show up correctly

### DIFF
--- a/src/wizards/tokenSwapDealWizard/components/stageButtons/stageButtons.ts
+++ b/src/wizards/tokenSwapDealWizard/components/stageButtons/stageButtons.ts
@@ -43,6 +43,7 @@ export class stageButtons {
       this.showSubmit = this.showSubmitButton();
     }
 
+    this.connectedAddress = this.ethereumService.defaultAccountAddress;
     this.accountSubscription = this.eventAggregator.subscribe("Network.Changed.Account", address => {
       this.connectedAddress = address;
     });


### PR DESCRIPTION
## What was done
Set the default address

## Testing
1. be connected
2. Reach Submit stage

#### Before
"Connect to submit" button showed up

#### After
"Submit" button

![grafik](https://user-images.githubusercontent.com/30693990/157778126-d613707e-884d-49b9-8b66-d6401cd8b039.png)
