### PR TITLE
fix(tokenDetails): only add default, when there is non

### DIFF
--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
@@ -128,8 +128,12 @@ export class TokenDetailsStage {
 
   private addDefaultValuesToRegistrationData(wizardType: WizardType) {
     if (wizardType === WizardType.createPartneredDeal) {
-      this.addToken(this.wizardState.registrationData.primaryDAO.tokens);
-      this.addToken(this.wizardState.registrationData.partnerDAO.tokens);
+      if (this.wizardState.registrationData.primaryDAO.tokens.length === 0) {
+        this.addToken(this.wizardState.registrationData.primaryDAO.tokens);
+      }
+      if (this.wizardState.registrationData.partnerDAO.tokens.length === 0) {
+        this.addToken(this.wizardState.registrationData.partnerDAO.tokens);
+      }
     }
   }
 }


### PR DESCRIPTION
## What was done
- add check to only add, when array is empty

## Testing
see ticket

#### Before
upon (re-) opening of token details stage, a new token was added

#### After
only add token, when array is empty