### PR TITLE
fix(tokenDetails): address now uses etherscanlink

### DIFF
--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
@@ -119,7 +119,13 @@
       <div class="detailsTable detailsTableInViewMode">
         <div class="detailsCell">
           <p>Token address</p>
-          <p>${token.address || '-' | smallHexString }</p>
+          <p if.bind="token.address">
+            <etherscanlink
+              text="${token.address | smallHexString}"
+              address.bind="token.address">
+            </etherscanlink>
+          </p>
+          <p else>-</p>
         </div>
 
         <div class="detailsCell detailsCellAmount">


### PR DESCRIPTION
## What was done
- add etherscanlink to address
- checked all other stages for protenial address, but others only have address in input field (-> need not to be hot?!)
![image](https://user-images.githubusercontent.com/30693990/157853889-d895e22d-4148-42f2-b89c-e33a1f9af925.png)


## Testing
1. Token Details stage

#### Before
not hot and tooltip

#### After
etherscanlink