### PR TITLE
#319 - Removed the `edit` button from the comment view

### DIFF
--- a/src/dealDashboard/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/discussionThread/singleComment/singleComment.html
@@ -53,7 +53,8 @@
         </div>
         <div if.bind="comment.author === connectedAddress && isConnected" class="vote action">
           <pbutton type="tertiary" click.delegate="delete()">Delete</pbutton>
-          <pbutton type="tertiary" disabled click.delegate="edit()">Edit</pbutton>
+          <!-- Commenting out until `edit` is implemented in the convo.space -->
+          <!-- <pbutton type="tertiary" disabled click.delegate="edit()">Edit</pbutton> -->
           <pbutton type="tertiary" if.bind="!isReplying" click.delegate="reply()">
             ${!highlighted ? "Reply" : "Cancel"}
             &nbsp;<i class="fas fa-reply"></i>


### PR DESCRIPTION
## What was done
Removed the `edit` button from the comment view.
## Testing

#### Before
![image](https://user-images.githubusercontent.com/2517870/157877236-a904dec2-25b6-4478-a4dd-56eccefe4354.png)

#### After
![image](https://user-images.githubusercontent.com/2517870/157877256-066580e5-decd-406c-b124-31f7d7203d12.png)
