### PR TITLE
#329 - Make an offer wizard should add Token form, if non present

### DIFF
--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
@@ -116,7 +116,7 @@ export class TokenDetailsStage {
   }
 
   private getDefaultTokenDetailsViewModes(wizardType: WizardType, dao?: IDAO): ("view" | "edit")[] {
-    return [WizardType.createOpenProposal, WizardType.createPartneredDeal].includes(wizardType)
+    return this.isCreatingDealLike(wizardType)
       ? []
       : dao?.tokens?.map(() => "view") ?? [];
   }
@@ -127,7 +127,7 @@ export class TokenDetailsStage {
   }
 
   private addDefaultValuesToRegistrationData(wizardType: WizardType) {
-    if (wizardType === WizardType.createPartneredDeal) {
+    if (this.isCreatingPartneredDealLike(wizardType)) {
       if (this.wizardState.registrationData.primaryDAO.tokens.length === 0) {
         this.addToken(this.wizardState.registrationData.primaryDAO.tokens);
       }
@@ -135,5 +135,17 @@ export class TokenDetailsStage {
         this.addToken(this.wizardState.registrationData.partnerDAO.tokens);
       }
     }
+  }
+
+  private isCreatingPartneredDealLike(wizardType: WizardType): boolean {
+    return [WizardType.createPartneredDeal, WizardType.makeAnOffer].includes(wizardType);
+  }
+
+  private isCreatingDealLike(wizardType: WizardType): boolean {
+    return [
+      WizardType.createOpenProposal,
+      WizardType.createPartneredDeal,
+      WizardType.makeAnOffer,
+    ].includes(wizardType);
   }
 }


### PR DESCRIPTION
## What was done
- add make an offer to the checks

## Testing
(Note, currently can only navigate via url to make an offer wizard)
see ticket

#### Before
https://prime-deals-dev.vercel.app/make-an-offer/open_deals_stream_hash_1/token-details
![image](https://user-images.githubusercontent.com/30693990/157886062-4256765b-d0fe-4233-ab02-8cd000cbe018.png)


#### After
https://prime-deals-dapp-git-fix-329-make-an-offer-token-form-curvelabs.vercel.app/make-an-offer/open_deals_stream_hash_1/token-details
![image](https://user-images.githubusercontent.com/30693990/157885894-21865083-71a9-452a-b508-6e063e6483a1.png)
