### PR TITLE
styles(navbar): add balanced padding

### DIFF
--- a/src/navbar/navbar.scss
+++ b/src/navbar/navbar.scss
@@ -55,7 +55,7 @@ $menu-open-duration: 0.1s;
         border-bottom: 3px solid $BG01;
         cursor: pointer;
         color: $Neutral04;
-        padding: 12px 12px 12px 0;
+        padding: 12px;
         align-items: center;
         justify-items: start;
         column-gap: 12px;


### PR DESCRIPTION
## What was done

## Testing

#### Before

#### After
![image](https://user-images.githubusercontent.com/30693990/158366990-c19c6241-93f5-42a1-a9d5-b61e7781f15d.png)

## Note
Adding more padding shifted the whole container to the right a bit.
I tried to accommodate to that by reducing container column-gap.
This is the best I could do with no exact padding values in the mocks
 
![navbar-add-padding](https://user-images.githubusercontent.com/30693990/158370762-d3622104-246f-4041-b283-89313fd1d5d3.png)

