### PR TITLE
383 discussion thread always shows is private when not connected

### DIFF
--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -35,7 +35,7 @@
       authorized.bind="authorized"
       deal.bind="deal"
       discussion-id.bind="discussionId"
-      show.bind="authorized || !this.deal.registrationData.isPrivate"
+      show.bind="authorized || !deal.registrationData.isPrivate"
     ></deal-discussion>
   </main>
 </template>

--- a/src/dealDashboard/dealDashboard.ts
+++ b/src/dealDashboard/dealDashboard.ts
@@ -7,7 +7,7 @@ import { DealService } from "../services/DealService";
 @autoinject
 export class DealDashboard {
   private deal: DealTokenSwap;
-  discussionId?: string;
+  discussionId?: string = "";
   private dealId: string;
 
   constructor(

--- a/src/dealDashboard/dealDashboard.ts
+++ b/src/dealDashboard/dealDashboard.ts
@@ -7,7 +7,7 @@ import { DealService } from "../services/DealService";
 @autoinject
 export class DealDashboard {
   private deal: DealTokenSwap;
-  discussionId?: string = "";
+  discussionId?: string;
   private dealId: string;
 
   constructor(

--- a/src/dealDashboard/dealDiscussion/dealDiscussion.html
+++ b/src/dealDashboard/dealDiscussion/dealDiscussion.html
@@ -1,16 +1,15 @@
 <template>
   <require from="./discussionsList/discussionsList"></require>
   <require from="./discussionThread/discussionThread"></require>
-
-  <discussions-list
-    authorized.bind="authorized"
-    deal.bind="deal"
-    discussion-id.two-way="discussionId"
-    if.to-view="!discussionId">
-  </discussions-list>
   <discussion-thread
     deal.bind="deal"
     discussion-id.two-way="discussionId"
-    else>
+    if.to-view="discussionId">
   </discussion-thread>
+  <discussions-list
+    if.to-view="!discussionId"
+    authorized.bind="authorized"
+    deal.bind="deal"
+    discussion-id.two-way="discussionId">
+  </discussions-list>
 </template>

--- a/src/dealDashboard/dealDiscussion/dealDiscussion.ts
+++ b/src/dealDashboard/dealDiscussion/dealDiscussion.ts
@@ -1,4 +1,4 @@
-import { autoinject, bindingMode } from "aurelia-framework";
+import { autoinject } from "aurelia-framework";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { DealTokenSwap } from "entities/DealTokenSwap";
 import "./dealDiscussion.scss";
@@ -7,5 +7,5 @@ import "./dealDiscussion.scss";
 export class DealDiscussion {
   @bindable deal: DealTokenSwap;
   @bindable.booleanAttr authorized = false;
-  @bindable.string({defaultBindingMode: bindingMode.twoWay}) discussionId?: string;
+  @bindable discussionId?: string;
 }

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -30,12 +30,8 @@
           Loading comments...
         </div>
 
-        <div if.bind="!threadComments.length && isMember && !isLoading.discussions" class="no comment">
-          This discussion has no comments yet.
-        </div>
-
-        <div if.bind="!threadComments.length && !isMember && !isLoading.discussions" class="no comment">
-          This discussion is private.
+        <div else class="no comment">
+          ${noCommentsText}
         </div>
 
         <div 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -97,6 +97,16 @@ export class DiscussionThread {
     }
   }
 
+  @computedFrom("isLoading.discussions", "isMember", "threadComments.length")
+  private get noCommentsText(): string {
+    if (!this.isLoading.discussions && !this.threadComments.length) {
+      return (!this.isMember && this.deal.registrationData.isPrivate)
+        ? "This discussion is private."
+        : "This discussion has no comments yet.";
+    }
+    return "";
+  }
+
   private async initialize(isIdChange = false): Promise<void> {
     this.isLoading.discussions = true;
 
@@ -340,6 +350,6 @@ export class DiscussionThread {
   }
 
   private navigateTo() {
-    this.discussionId = null;
+    this.discussionId = "";
   }
 }

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -92,7 +92,7 @@ export class DiscussionThread {
   }
 
   discussionIdChanged() {
-    if (this.deal) {
+    if (this.deal && this.discussionId) {
       this.initialize(true);
     }
   }
@@ -350,6 +350,6 @@ export class DiscussionThread {
   }
 
   private navigateTo() {
-    this.discussionId = "";
+    this.discussionId = null;
   }
 }

--- a/src/services/CeramicServiceMock.ts
+++ b/src/services/CeramicServiceMock.ts
@@ -109,7 +109,7 @@ const _registration1: IDealRegistrationTokenSwap = {
   },
   keepAdminRights: false,
   offersPrivate: false,
-  isPrivate: false,
+  isPrivate: true,
   createdAt: new Date("2022-01-27"),
   modifiedAt: null,
   createdByAddress: "",


### PR DESCRIPTION
## What was done
-[x] Fixed a bug when empty thread shows as private if no wallet is connected.
-[x] Fixed small typo, causing a deal is private discussion section show even if not authorized.
-[x] Converted the deal `open_deals_stream_hash_1` to private, for easier testing of private-deals functionality.