### PR TITLE
388 - Added override option for suffix behavior of date-diffs

### DIFF
--- a/src/deals/list/deals.ts
+++ b/src/deals/list/deals.ts
@@ -63,7 +63,7 @@ export class Deals {
    * @returns
    */
   public getFormattedTime(dateTime: Date): string {
-    return this.dateService.formattedTime(dateTime).diff("en-US").replace("a ", "1 ");
+    return this.dateService.formattedTime(dateTime).diff("en-US", false).replace("a ", "1 ");
   }
 
   /**

--- a/src/services/DateService.ts
+++ b/src/services/DateService.ts
@@ -1,4 +1,4 @@
-﻿import * as moment from "moment-timezone";
+import * as moment from "moment-timezone";
 
 import { autoinject } from "aurelia-framework";
 
@@ -440,7 +440,7 @@ export class DateService {
    *
    * formatDate(new Date()).diff();
    */
-  public formattedTime(date: Date | number): {short: (locale: string) => string, diff: (locale?: string ) => string} {
+  public formattedTime(date: Date | number): {short: (locale: string) => string, diff: (locale?: string, withoutSuffix?: boolean ) => string} {
     const _date = new Date(date);
 
     return {
@@ -448,9 +448,9 @@ export class DateService {
         locale,
         { year: "numeric", month: "short", day: "numeric" },
       ),
-      diff: (locale = "en-custom") => {
+      diff: (locale = "en-custom", withoutSuffix = true) => {
         if (!date) return "-";
-        return moment(date).locale(locale).fromNow();
+        return moment(date).locale(locale).fromNow(withoutSuffix);
       },
     };
   }


### PR DESCRIPTION
## What was done
Discussions last activity should not show the suffix `ago` in the last activity time-diff.
Added the option to override the suffix behavior of the diff method, to improve reusability.
Applied this fix to the `all-deals` page.