### PR TITLE
#386 - Deal information

### DIFF
--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -57,6 +57,14 @@ Given("I navigate to the Make an offer {string} stage", (stageTitle: keyof typeo
   cy.visit(url);
 });
 
+When("I'm viewing the Partnered Deal Dashboard", () => {
+  const dealId = "partnered_deals_stream_hash_2";
+  const url = `/deal/${dealId}`;
+  cy.visit(url);
+
+  cy.get(".dealDashboardContainer").should("be.visible");
+});
+
 Given("I edit a \"Partnered Deal\"", () => {
   const dealId = "partnered_deals_stream_hash_3";
   const url = `partnered-deal/${dealId}/edit/submit`;

--- a/cypress/integration/common/mobile.ts
+++ b/cypress/integration/common/mobile.ts
@@ -1,0 +1,5 @@
+import { Given } from "@badeball/cypress-cucumber-preprocessor/methods";
+
+Given("I'm in the mobile view", () => {
+  cy.viewport("iphone-8");
+});

--- a/cypress/integration/features/dealDashboard/deal-description-mobile.feature
+++ b/cypress/integration/features/dealDashboard/deal-description-mobile.feature
@@ -1,4 +1,4 @@
-Feature: Partnered Deal - Main
+Feature: Partnered Deal - Description - Mobile
   Background:
     Given I'm in the mobile view
     Given I'm viewing the Partnered Deal Dashboard

--- a/cypress/integration/features/dealDashboard/deal-description-mobile.feature
+++ b/cypress/integration/features/dealDashboard/deal-description-mobile.feature
@@ -3,7 +3,6 @@ Feature: Partnered Deal - Main
     Given I'm in the mobile view
     Given I'm viewing the Partnered Deal Dashboard
 
-  @focus
   Scenario: Partnered Deal - Mobile read more
     When the description text is long
     Then I can expand the text to read more

--- a/cypress/integration/features/dealDashboard/deal-description-mobile.feature
+++ b/cypress/integration/features/dealDashboard/deal-description-mobile.feature
@@ -1,0 +1,9 @@
+Feature: Partnered Deal - Main
+  Background:
+    Given I'm in the mobile view
+    Given I'm viewing the Partnered Deal Dashboard
+
+  @focus
+  Scenario: Partnered Deal - Mobile read more
+    When the description text is long
+    Then I can expand the text to read more

--- a/cypress/integration/features/dealDashboard/deal-description.feature
+++ b/cypress/integration/features/dealDashboard/deal-description.feature
@@ -1,4 +1,4 @@
-Feature: Partnered Deal - Main
+Feature: Partnered Deal - Description
   Background:
     Given I'm viewing the Partnered Deal Dashboard
 

--- a/cypress/integration/features/dealDashboard/deal-description.feature
+++ b/cypress/integration/features/dealDashboard/deal-description.feature
@@ -5,7 +5,6 @@ Feature: Partnered Deal - Main
   Scenario: Partnered Deal - Status
     Then I can view the current status of the Partnered Deal
 
-  @focus
   Scenario: Partnered Deal - Information
     Then I can view the title of the Partnered Deal
     And I can view the description of the Partnered Deal

--- a/cypress/integration/features/dealDashboard/deal-description.feature
+++ b/cypress/integration/features/dealDashboard/deal-description.feature
@@ -1,0 +1,11 @@
+Feature: Partnered Deal - Main
+  Background:
+    Given I'm viewing the Partnered Deal Dashboard
+
+  Scenario: Partnered Deal - Status
+    Then I can view the current status of the Partnered Deal
+
+  @focus
+  Scenario: Partnered Deal - Information
+    Then I can view the title of the Partnered Deal
+    And I can view the description of the Partnered Deal

--- a/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
@@ -11,9 +11,13 @@ When("the description text is long", () => {
     });
 });
 
-Then("I can view the current status of the Partnered Deal", () => {});
+Then("I can view the current status of the Partnered Deal", () => {
+  cy.get("[data-test='dealStatus']").should("be.visible");
+});
 
-Then("I can view the title of the Partnered Deal", () => {});
+Then("I can view the title of the Partnered Deal", () => {
+  cy.get("[data-test='dealTitle']").should("be.visible");
+});
 
 And("I can view the description of the Partnered Deal", () => {
   cy.get("[data-test='dealDescriptionText']").should("be.visible");

--- a/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
@@ -1,0 +1,9 @@
+import { And, Then } from "@badeball/cypress-cucumber-preprocessor/methods";
+
+Then("I can view the current status of the Partnered Deal", () => {});
+
+Then("I can view the title of the Partnered Deal", () => {});
+
+And("I can view the description of the Partnered Deal", () => {
+  cy.get("[data-test='dealDescription']").should("be.visible");
+});

--- a/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
@@ -5,5 +5,5 @@ Then("I can view the current status of the Partnered Deal", () => {});
 Then("I can view the title of the Partnered Deal", () => {});
 
 And("I can view the description of the Partnered Deal", () => {
-  cy.get("[data-test='dealDescription']").should("be.visible");
+  cy.get("[data-test='dealDescriptionText']").should("be.visible");
 });

--- a/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/deal-description.e2e.ts
@@ -1,4 +1,15 @@
-import { And, Then } from "@badeball/cypress-cucumber-preprocessor/methods";
+import { And, Then, When } from "@badeball/cypress-cucumber-preprocessor/methods";
+
+const MOBILE_MAX_LENGTH = 250;
+
+When("the description text is long", () => {
+  cy.get("[data-test='dealDescriptionText']")
+    .invoke("text").then(descriptionText => {
+      expect(descriptionText.trim().endsWith("...")).to.equal(true);
+      const cleanedLength = descriptionText.trim().length - 3; // - 3: "..." ellipsis dots
+      expect(cleanedLength).to.equal(MOBILE_MAX_LENGTH);
+    });
+});
 
 Then("I can view the current status of the Partnered Deal", () => {});
 
@@ -6,4 +17,14 @@ Then("I can view the title of the Partnered Deal", () => {});
 
 And("I can view the description of the Partnered Deal", () => {
   cy.get("[data-test='dealDescriptionText']").should("be.visible");
+});
+
+Then("I can expand the text to read more", () => {
+  cy.get("[data-test='readMoreDealDescription']").click();
+  cy.get("[data-test='dealDescriptionText']")
+    .invoke("text")
+    .then(descriptionText => {
+      const cleaned = descriptionText.trim();
+      expect(cleaned.length >= MOBILE_MAX_LENGTH).equals(true);
+    });
 });

--- a/cypress/integration/tests/deals/submit-stage.e2e.ts
+++ b/cypress/integration/tests/deals/submit-stage.e2e.ts
@@ -1,8 +1,7 @@
 import { Then } from "@badeball/cypress-cucumber-preprocessor/methods";
 
 Then("all the wizard registration data should be presented", () => {
-/* prettier-ignore */ console.log("TCL ~ file: submit-stage.e2e.ts ~ line 4 ~ Then ~ registration");
-
+  expect("TODO").to.equal("TODO");
 });
 
 Then("I should be notified, that the registration was successful", () => {

--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -10,12 +10,12 @@
     <deal-menubar deal.bind="deal"></deal-menubar>
 
     <section class="section top">
-      <h1 class="title heading heading1 gradient">
+      <h1 data-test="dealTitle" class="title heading heading1 gradient">
         ${deal.registrationData.proposal.title}
       </h1>
 
       <let deal-privacy-text="${deal.registrationData.isPrivate ? 'Private' : 'Public'}"></let>
-      <h2>• ${deal.status}, Recently updated (${dealPrivacyText})</h2>
+      <h2 data-test="dealStatus">• ${deal.status}, Recently updated (${dealPrivacyText})</h2>
     </section>
 
     <aside class="aside">

--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -11,9 +11,11 @@
 
     <section class="section top">
       <h1 class="title heading heading1 gradient">
-        Swap tokenized carbon credits for a better world
+        ${deal.registrationData.proposal.title}
       </h1>
-      <h2>* Active, Recently updated (Private)</h2>
+
+      <let deal-privacy-text="${deal.registrationData.isPrivate ? 'Private' : 'Public'}"></let>
+      <h2>• ${deal.status}, Recently updated (${dealPrivacyText})</h2>
     </section>
 
     <aside class="aside">

--- a/src/dealDashboard/dealDescription/dealDescription.html
+++ b/src/dealDashboard/dealDescription/dealDescription.html
@@ -6,6 +6,11 @@
   </p>
 
   <div class="mobileButtonContainerDealDescription">
-    <pbutton if.bind="showReadMoreButton" type="tertiary" click.delegate="readMore()">Read more</pbutton>
+    <pbutton
+      data-test="readMoreDealDescription"
+      if.bind="showReadMoreButton"
+      type="tertiary"
+      click.delegate="readMore()">
+      Read more</pbutton>
   </div>
 </template>

--- a/src/dealDashboard/dealDescription/dealDescription.html
+++ b/src/dealDashboard/dealDescription/dealDescription.html
@@ -2,11 +2,10 @@
   <p class="descriptionLabel">Description</p>
 
   <p data-test="dealDescriptionText" class="dealDescriptionText">
-    registrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationData
-    ${deal.registrationData.proposal.description}
+    ${descriptionText}
   </p>
 
   <div class="mobileButtonContainerDealDescription">
-    <pbutton type="tertiary">Read more</pbutton>
+    <pbutton if.bind="showReadMoreButton" type="tertiary" click.delegate="readMore()">Read more</pbutton>
   </div>
 </template>

--- a/src/dealDashboard/dealDescription/dealDescription.html
+++ b/src/dealDashboard/dealDescription/dealDescription.html
@@ -1,9 +1,7 @@
 <template>
   <p class="descriptionLabel">Description</p>
 
-  <p data-test="dealDescriptionText" class="dealDescriptionText">
-    ${descriptionText}
-  </p>
+  <pre data-test="dealDescriptionText" class="dealDescriptionText">${descriptionText}</pre>
 
   <div class="mobileButtonContainerDealDescription">
     <pbutton

--- a/src/dealDashboard/dealDescription/dealDescription.html
+++ b/src/dealDashboard/dealDescription/dealDescription.html
@@ -5,4 +5,8 @@
     registrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationData
     ${deal.registrationData.proposal.description}
   </p>
+
+  <div class="mobileButtonContainerDealDescription">
+    <pbutton type="tertiary">Read more</pbutton>
+  </div>
 </template>

--- a/src/dealDashboard/dealDescription/dealDescription.html
+++ b/src/dealDashboard/dealDescription/dealDescription.html
@@ -1,10 +1,8 @@
 <template>
-  <header>
-    <h2 class="subtitle heading heading3">Overview</h2>
-  </header>
-  <p>
-    We propose AcmeDAO and GreenLabDAO to swap 1,000 ACM and 140,000 GLD to solidify the partnership between the two
-    projects and align their incentives going forward. AcmeDAO also agrees to continue developing current and future
-    products on top of GreenLabDAO’s protocol, which GreenLabDAO will help support promotionally.
+  <p class="descriptionLabel">Description</p>
+
+  <p data-test="dealDescription" class="dealDescription">
+    registrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationData
+    ${deal.registrationData.proposal.description}
   </p>
 </template>

--- a/src/dealDashboard/dealDescription/dealDescription.html
+++ b/src/dealDashboard/dealDescription/dealDescription.html
@@ -1,7 +1,7 @@
 <template>
   <p class="descriptionLabel">Description</p>
 
-  <p data-test="dealDescription" class="dealDescription">
+  <p data-test="dealDescriptionText" class="dealDescriptionText">
     registrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationDataregistrationData
     ${deal.registrationData.proposal.description}
   </p>

--- a/src/dealDashboard/dealDescription/dealDescription.scss
+++ b/src/dealDashboard/dealDescription/dealDescription.scss
@@ -22,7 +22,7 @@ deal-description {
     max-width: 335px;
     margin-bottom: 56px;
 
-    .dealDescription {
+    .dealDescriptionText {
       margin-bottom: 28px;
     }
 

--- a/src/dealDashboard/dealDescription/dealDescription.scss
+++ b/src/dealDashboard/dealDescription/dealDescription.scss
@@ -5,10 +5,30 @@ deal-description {
   margin-bottom: 100px;
   word-wrap: break-word;
   font-family: Inter;
+  line-height: 24px;
 
   .descriptionLabel {
     color: $Secondary02;
     font-weight: $font-bold;
-    line-height: 24px;
+  }
+
+  .mobileButtonContainerDealDescription {
+    display: none;
+  }
+}
+
+@media screen and (max-width: $MobileWidth) {
+  deal-description {
+    max-width: 335px;
+    margin-bottom: 56px;
+
+    .dealDescription {
+      margin-bottom: 28px;
+    }
+
+    .mobileButtonContainerDealDescription {
+      display: flex;
+      justify-content: center;
+    }
   }
 }

--- a/src/dealDashboard/dealDescription/dealDescription.scss
+++ b/src/dealDashboard/dealDescription/dealDescription.scss
@@ -1,3 +1,14 @@
+@import "../../resources/elements/primeDesignSystem/variables";
+
 deal-description {
+  width: $sectionWidth;
   margin-bottom: 100px;
+  word-wrap: break-word;
+  font-family: Inter;
+
+  .descriptionLabel {
+    color: $Secondary02;
+    font-weight: $font-bold;
+    line-height: 24px;
+  }
 }

--- a/src/dealDashboard/dealDescription/dealDescription.scss
+++ b/src/dealDashboard/dealDescription/dealDescription.scss
@@ -12,6 +12,8 @@ deal-description {
     font-weight: $font-bold;
   }
 
+  @include pre;
+
   .mobileButtonContainerDealDescription {
     display: none;
   }

--- a/src/dealDashboard/dealDescription/dealDescription.ts
+++ b/src/dealDashboard/dealDescription/dealDescription.ts
@@ -16,6 +16,8 @@ export class DealDescription {
   private descriptionText: string | undefined;
   private originalDescriptionText = "";
 
+  private resizeWatcher;
+
   @computedFrom("descriptionText")
   get showReadMoreButton() {
     return this.descriptionText.length < this.originalDescriptionText.length;
@@ -24,16 +26,30 @@ export class DealDescription {
   bind() {
     this.originalDescriptionText = this.deal.registrationData.proposal.description;
 
+    this.watchResize();
+    this.changeTextIfMobile();
+
+    if (this.descriptionText === undefined) {
+      this.descriptionText = this.originalDescriptionText;
+    }
+  }
+
+  watchResize() {
+    this.resizeWatcher = () => this.changeTextIfMobile();
+    window.addEventListener("resize", this.resizeWatcher);
+  }
+
+  changeTextIfMobile() {
     if (MobileService.isMobile()) {
       if (this.originalDescriptionText.length > MOBILE_MAX_LENGTH) {
         const shortened = this.originalDescriptionText.substring(0, MOBILE_MAX_LENGTH);
         this.descriptionText = `${shortened}...`;
       }
     }
+  }
 
-    if (this.descriptionText === undefined) {
-      this.descriptionText = this.originalDescriptionText;
-    }
+  detached() {
+    window.removeEventListener("resize", this.resizeWatcher);
   }
 
   private readMore(): void {

--- a/src/dealDashboard/dealDescription/dealDescription.ts
+++ b/src/dealDashboard/dealDescription/dealDescription.ts
@@ -1,9 +1,42 @@
-import { autoinject } from "aurelia-framework";
+import { autoinject, computedFrom } from "aurelia-framework";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { DealTokenSwap } from "entities/DealTokenSwap";
+import { MobileService } from "services/MobileService";
 import "./dealDescription.scss";
+
+const MOBILE_MAX_LENGTH = 250;
 
 @autoinject
 export class DealDescription {
   @bindable deal: DealTokenSwap;
+
+  /**
+   * Description text is shortened to 250 words
+   */
+  private descriptionText: string | undefined;
+  private originalDescriptionText = "";
+
+  @computedFrom("descriptionText")
+  get showReadMoreButton() {
+    return this.descriptionText.length < this.originalDescriptionText.length;
+  }
+
+  bind() {
+    this.originalDescriptionText = this.deal.registrationData.proposal.description;
+
+    if (MobileService.isMobile()) {
+      if (this.originalDescriptionText.length > MOBILE_MAX_LENGTH) {
+        const shortened = this.originalDescriptionText.substring(0, MOBILE_MAX_LENGTH);
+        this.descriptionText = `${shortened}...`;
+      }
+    }
+
+    if (this.descriptionText === undefined) {
+      this.descriptionText = this.originalDescriptionText;
+    }
+  }
+
+  private readMore(): void {
+    this.descriptionText = `${this.originalDescriptionText}`;
+  }
 }

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -4,6 +4,7 @@
  * this is to sync with when the navbar controls start to break
  */
 $PageBreakWidth: 900px;
+$MobileWidth: 375px;
 
 $border-radius-small: 6px;
 $border-radius-normal: 10px;

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -83,5 +83,6 @@ $heading: Aeonik;
 }
 
 $pPopupNotificationWidth: 336px;
+$sectionWidth: 645px;
 
 $pCardBackgroundColor: $BG02 !global;

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -6,6 +6,10 @@
 $PageBreakWidth: 900px;
 $MobileWidth: 375px;
 
+:root {
+  --mobile-width: #{$MobileWidth};
+}
+
 $border-radius-small: 6px;
 $border-radius-normal: 10px;
 

--- a/src/services/MobileService.ts
+++ b/src/services/MobileService.ts
@@ -1,0 +1,10 @@
+import { Utils } from "./utils";
+
+export class MobileService {
+  public static isMobile(): boolean {
+    const mobileWidth = Utils.getCssVariable("--mobile-width");
+    const isMobile = window.matchMedia(`only screen and (max-width: ${mobileWidth})`).matches;
+
+    return isMobile;
+  }
+}


### PR DESCRIPTION
## What was done
update dashboard skeleton with 
- deal privacy
- deal title 
- deal status (only text, no styling)
- read more

#### Not in this PR
- deal status (styling)
- deal activity (time-left)

## Testing
- choose a deal from the deal carousel from the home page
- Responsivness: into mobile view -> deal description longer than 250? -> read more button

#### Before

#### After
![grafik](https://user-images.githubusercontent.com/30693990/158644732-f223b1f0-4aa6-4ac7-b05e-d36f6e9f9f00.png)
