### PR TITLE
#382 - styles(scroller): allow touch scrolling

### DIFF
--- a/src/resources/elements/horizontal-scroller/horizontal-scroller.scss
+++ b/src/resources/elements/horizontal-scroller/horizontal-scroller.scss
@@ -12,7 +12,11 @@
     padding-left: auto;
     padding-right: auto;
     -webkit-overflow-scrolling: touch;
-    overflow: hidden;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    scrollbar-width: none; // Firefox
+
 
     > div {
       flex: 0 0 auto;


### PR DESCRIPTION
## What was done
- copy over from Prime Launch
```scss
// prime launch horizontal scorller
  .scroller {
    display: flex;
    flex-wrap: nowrap;
    overflow-x: auto;
    width: 100%;
    -webkit-overflow-scrolling: touch;
    &::-webkit-scrollbar {
      display: none;
    }

    > div {
      flex: 0 0 auto;
    }
  }
```

- also add firefox support (https://stackoverflow.com/questions/19580366/hide-scrollbar-in-firefox)

## Testing

#### Before

#### After