### PR TITLE
#337+408 - Fixed issues where deleting a token detail card or a term clause, the…

### DIFF
--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -165,6 +165,11 @@ Then("I can proceed to the next step", () => {
   });
 });
 
+Then("I am notified, that I am unable to proceed due to validation errors", () => {
+  cy.contains("[data-test='pPopupNotification']", "Unable to proceed, please check the page for validation errors")
+    .should("be.visible");
+});
+
 function waitForTokenAddressLoaded() {
   cy.contains("[data-test='tokenDetails']", "Searching token address details").should("be.visible");
   const timeoutForAddressRequest = 20000;

--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -157,5 +157,7 @@ Then("I can proceed to the next step", () => {
 });
 
 function waitForTokenAddressLoaded() {
-  throw new Error("Function not implemented.");
+  cy.contains("[data-test='tokenDetails']", "Searching token address details").should("be.visible");
+  const timeoutForAddressRequest = 20000;
+  cy.contains("p", "Symbol", {timeout: timeoutForAddressRequest}).should("be.visible");
 }

--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -99,6 +99,15 @@ Then("I am presented with the {string} {string} stage", (wizardTitle: keyof type
   cy.url().should("contain", `/initiate/token-swap/${wizardTitlesToURLs[wizardTitle]}/${stageTitlesToURLs[stageTitle]}`);
 });
 
+When("I fill in the {string} field with an invalid address", (field: string) => {
+  const invalidAddress = "invalid address";
+  withinWizardSection().within(() => {
+    cy.get(`[data-test='proposal-${field.toLowerCase().replaceAll(" ", "-")}-field']`).within(() => {
+      cy.get("input, textarea").type(invalidAddress);
+    });
+  });
+});
+
 When("I fill in the {string} field with {string}", (field: string, value: string) => {
   withinWizardSection().within(() => {
     cy.get(`[data-test='proposal-${field.toLowerCase().replaceAll(" ", "-")}-field']`).within(() => {

--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -16,6 +16,16 @@ const stageTitlesToURLs = {
   "Submit": "submit",
 } as const;
 
+export let sectionTitle = "";
+
+export function withinWizardSection() {
+  return cy.contains("[data-test='section-title']", sectionTitle).parents(".stageSection");
+}
+
+Given(/^I want to fill in information for the "(.*)" section$/, (_sectionTitle: string) => {
+  sectionTitle = _sectionTitle;
+});
+
 Then("I am presented the option to choose a partner", () => {
   cy.url().should("match", /(initiate\/token-swap$)/);
 });
@@ -49,6 +59,14 @@ Given("I navigate to the {string} {string} stage", (wizardTitle: keyof typeof wi
   if (!stageTitlesToURLs[stageTitle]) {
     throw new Error(`Stage  ${stageTitle} does not exist in the list`);
   }
+
+  if (wizardTitle === "Make an offer") {
+    const dealId = "open_deals_stream_hash_1";
+    const url = `make-an-offer/${dealId}/${stageTitlesToURLs[stageTitle]}`;
+    cy.visit(url).wait(1500);
+    return;
+  }
+
   cy.visit(`/initiate/token-swap/${wizardTitlesToURLs[wizardTitle]}/${stageTitlesToURLs[stageTitle]}`).wait(1500);
 });
 
@@ -82,8 +100,14 @@ Then("I am presented with the {string} {string} stage", (wizardTitle: keyof type
 });
 
 When("I fill in the {string} field with {string}", (field: string, value: string) => {
-  cy.get(`[data-test='proposal-${field.toLowerCase().replaceAll(" ", "-")}-field']`).within(() => {
-    cy.get("input, textarea").type(value);
+  withinWizardSection().within(() => {
+    cy.get(`[data-test='proposal-${field.toLowerCase().replaceAll(" ", "-")}-field']`).within(() => {
+      cy.get("input, textarea").type(value);
+    });
+
+    if (field === "Token address") {
+      waitForTokenAddressLoaded();
+    }
   });
 });
 
@@ -123,3 +147,15 @@ Then("I should be redirected to the Home Page", () => {
     expect(url).to.include("home");
   });
 });
+
+Then("I can proceed to the next step", () => {
+  cy.url().then(url => {
+    const oldUrl = url;
+    cy.get("[data-test='wizard-proceed-button']").click();
+    cy.url().should("not.equal", oldUrl);
+  });
+});
+
+function waitForTokenAddressLoaded() {
+  throw new Error("Function not implemented.");
+}

--- a/cypress/integration/features/deals/open-proposal/stage5.feature
+++ b/cypress/integration/features/deals/open-proposal/stage5.feature
@@ -8,7 +8,6 @@ Feature: "Token Details" stage (Stage 5) - Open Proposal
   Scenario: Token Details - Optional
     Then I can proceed to the next step
 
-  @focus
   Scenario: Proceeding to the next stage - only Token Details
     Given I want to fill in information for the "Tokens" section
     Given I add a Token Details form

--- a/cypress/integration/features/deals/open-proposal/stage5.feature
+++ b/cypress/integration/features/deals/open-proposal/stage5.feature
@@ -8,15 +8,16 @@ Feature: "Token Details" stage (Stage 5) - Open Proposal
   Scenario: Token Details - Optional
     Then I can proceed to the next step
 
-  # Scenario: Proceeding to the next stage - only Token Details
-  #   Given I want to fill in information for the "Tokens" section
-  #   Given I add a Token Details form
-  #   When I fill in the "Token address" field with "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad"
-  #   And I fill in the "Token amount" field with "123"
-  #   And I fill in the "Vested Period" field with "123"
-  #   And I fill in the "Cliff Period" field with "123"
-  #   And I try to save the Token Details form for the "(.*)"
-  #   Then I can proceed to the next step
+  @focus
+  Scenario: Proceeding to the next stage - only Token Details
+    Given I want to fill in information for the "Tokens" section
+    Given I add a Token Details form
+    When I fill in the "Token address" field with "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad"
+    And I fill in the "Token amount" field with "123"
+    And I fill in the "Vested Period" field with "123"
+    And I fill in the "Cliff Period" field with "123"
+    And I try to save the Token Details form
+    Then I can proceed to the next step
 
   Scenario: Proceeding to the next stage - only Execution Period
     Given I want to fill in information for the "Execution Period" section

--- a/cypress/integration/features/deals/open-proposal/stage5.feature
+++ b/cypress/integration/features/deals/open-proposal/stage5.feature
@@ -1,0 +1,25 @@
+Feature: "Token Details" stage (Stage 5) - Open Proposal
+  Background:
+    Given I navigate to the "Open proposal" "Token Details" stage
+
+  #####################################################
+
+  # Need to add for "Edit Open proposal case too?"
+  Scenario: Token Details - Optional
+    Then I can proceed to the next step
+
+  # Scenario: Proceeding to the next stage - only Token Details
+  #   Given I want to fill in information for the "Tokens" section
+  #   Given I add a Token Details form
+  #   When I fill in the "Token address" field with "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad"
+  #   And I fill in the "Token amount" field with "123"
+  #   And I fill in the "Vested Period" field with "123"
+  #   And I fill in the "Cliff Period" field with "123"
+  #   And I try to save the Token Details form for the "(.*)"
+  #   Then I can proceed to the next step
+
+  Scenario: Proceeding to the next stage - only Execution Period
+    Given I want to fill in information for the "Execution Period" section
+    And I fill in the "Execution Period" field with "123"
+    Then I can proceed to the next step
+

--- a/cypress/integration/features/deals/open-proposal/terms.feature
+++ b/cypress/integration/features/deals/open-proposal/terms.feature
@@ -26,12 +26,23 @@ Feature: Terms - Open Proposal
 
   Scenario: Delete a Clause
     Given I have 2 existing Clauses
-    When I delete the latest Clause
+    When I delete the last Clause
     Then I should only have 1 Clause
 
   Scenario: Delete a Clause - No deletion for single Clause
     Given I have 1 existing Clause
     Then I cannot delete the Clause
+
+  @regression
+  Scenario: Delete a Clause - Correct view state
+    Given I have 2 existing Clause
+    When I add content to the first Clause
+    And I save the changes to the first Clause
+    And I add content to the last Clause
+    And I save the changes to the last Clause
+    When I edit the last Clause
+    And I delete the last Clause
+    Then the first Clause should be in View mode
 
   Scenario: Proceeding with incomplete Clauses
     When I try to proceed to next step

--- a/cypress/integration/features/deals/partnered-deal/stage5.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage5.feature
@@ -1,7 +1,50 @@
 Feature: "Token Details" stage (Stage 5)
-
   Background:
     Given I navigate to the "Partnered Deal" "Token Details" stage
+
+  #####################################################
+
+  Scenario Outline: Add a default empty form, when there is no Token
+    Given I navigate to the "<WizardType>" "Token Details" stage
+    Then I am presented with an empty Token Details form
+
+    Examples:
+      | WizardType     |
+      | Partnered Deal |
+      | Make an offer  |
+
+
+  Scenario: Token Details - Address
+  Scenario: Token Details - Amount
+  Scenario: Token Details - Instant Transfer Set up
+  Scenario: Token Details - Vesting Set up
+
+  Scenario: Add Token
+
+  Scenario: No Delete, when there is only one Token form
+    Given I have 1 Token Details form for the "Primary DAO Tokens"
+    Then I cannot delete a Token Details form
+
+  Scenario: Delete Token
+    Given I have 2 Token Details forms for the "Primary DAO Tokens"
+    Then I can delete a Token Details form
+
+  Scenario: Save Token
+    Given I have 1 Token Details form for the "Primary DAO Tokens"
+    When I try to save the Token Details form for the "Primary DAO Tokens"
+    And I am presented with the "Address is required" error message for the "Token address" field
+    And I am presented with the "Amount is required" error message for the "Token amount" field
+    And the Token Details form was not saved for the "Primary DAO Tokens"
+
+  #####################################################
+
+  Scenario: Partner DAO
+
+  #####################################################
+
+  Scenario: Execution Period
+
+  #####################################################
 
   Scenario: Validates required fields
     When I try to proceed to next step
@@ -31,13 +74,5 @@ Feature: "Token Details" stage (Stage 5)
     And I am presented with the "Please provide a vesting period" error message for the "Vested Period" field
     And I am presented with the "Please provide a cliff period" error message for the "Cliff Period" field
 
+  Scenario: Validation - Proceeding when unsaved data
 
-#  This scenario needs the next stage in order to be tested. (replace "<Next stage>" with the proper next stage name)
-#  Scenario: I proceed from the "Token Details" stage after filling required fields correctly
-#    When I fill in the "Token address" field with "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad"
-#    And I fill in the "Token amount" field with "123"
-#    And I fill in the "Vested Period" field with "123"
-#    And I fill in the "Cliff Period" field with "123"
-#    And I fill in the "Execution Period" field with "123"
-#    And I try to proceed to next step
-#    Then I am presented with the "Partnered Deal" "<Next stage>" stage

--- a/cypress/integration/features/deals/partnered-deal/stage5.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage5.feature
@@ -22,19 +22,19 @@ Feature: "Token Details" stage (Stage 5)
   Scenario: Add Token
 
   Scenario: No Delete, when there is only one Token form
-    Given I have 1 Token Details form for the "Primary DAO Tokens"
+    Given I have 1 Token Details form
     Then I cannot delete a Token Details form
 
   Scenario: Delete Token
-    Given I have 2 Token Details forms for the "Primary DAO Tokens"
+    Given I have 2 Token Details forms
     Then I can delete a Token Details form
 
   Scenario: Save Token
-    Given I have 1 Token Details form for the "Primary DAO Tokens"
-    When I try to save the Token Details form for the "Primary DAO Tokens"
+    Given I have 1 Token Details form
+    When I try to save the Token Details form
     And I am presented with the "Address is required" error message for the "Token address" field
     And I am presented with the "Amount is required" error message for the "Token amount" field
-    And the Token Details form was not saved for the "Primary DAO Tokens"
+    And the Token Details form was not saved
 
   #####################################################
 

--- a/cypress/integration/features/deals/partnered-deal/stage5.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage5.feature
@@ -14,23 +14,26 @@ Feature: "Token Details" stage (Stage 5)
       | Make an offer  |
 
 
-  Scenario: Token Details - Address
-  Scenario: Token Details - Amount
-  Scenario: Token Details - Instant Transfer Set up
-  Scenario: Token Details - Vesting Set up
+  # Scenario: Token Details - Address
+  # Scenario: Token Details - Amount
+  # Scenario: Token Details - Instant Transfer Set up
+  # Scenario: Token Details - Vesting Set up
 
-  Scenario: Add Token
+  # Scenario: Add Token
 
   Scenario: No Delete, when there is only one Token form
-    Given I have 1 Token Details form
+    Given I want to fill in information for the "Primary DAO Tokens" section
+    And I have 1 Token Details form
     Then I cannot delete a Token Details form
 
   Scenario: Delete Token
-    Given I have 2 Token Details forms
+    Given I want to fill in information for the "Primary DAO Tokens" section
+    And I have 2 Token Details forms
     Then I can delete a Token Details form
 
   Scenario: Save Token
-    Given I have 1 Token Details form
+    Given I want to fill in information for the "Primary DAO Tokens" section
+    And I have 1 Token Details form
     When I try to save the Token Details form
     And I am presented with the "Address is required" error message for the "Token address" field
     And I am presented with the "Amount is required" error message for the "Token amount" field
@@ -38,11 +41,11 @@ Feature: "Token Details" stage (Stage 5)
 
   #####################################################
 
-  Scenario: Partner DAO
+  # Scenario: Partner DAO
 
   #####################################################
 
-  Scenario: Execution Period
+  # Scenario: Execution Period
 
   #####################################################
 
@@ -74,5 +77,5 @@ Feature: "Token Details" stage (Stage 5)
     And I am presented with the "Please provide a vesting period" error message for the "Vested Period" field
     And I am presented with the "Please provide a cliff period" error message for the "Cliff Period" field
 
-  Scenario: Validation - Proceeding when unsaved data
+  # Scenario: Validation - Proceeding when unsaved data
 

--- a/cypress/integration/features/deals/partnered-deal/stage5.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage5.feature
@@ -65,13 +65,15 @@ Feature: "Token Details" stage (Stage 5)
     And I am presented with the "Execution period is required" error message for the "Execution Period" field
 
   Scenario: Validates if the wallet address has the correct format
-    When I fill in the "Token address" field with "wrong address" in the "Primary DAO tokens" section
+    Given I want to fill in information for the "Primary DAO Tokens" section
+    When I fill in the "Token address" field with an invalid address
     And I try to proceed to next step
     Then I am presented with the "Partnered Deal" "Token Details" stage
     And I am presented with the "Please enter a valid ethereum address" error message for the "Token address" field
 
   Scenario: Validates vesting periods
-    When I fill in the "Token amount" field with "123" in the "Primary DAO tokens" section
+    Given I want to fill in information for the "Primary DAO Tokens" section
+    When I fill in the "Token amount" field with "123"
     And I try to proceed to next step
     Then I am presented with the "Partnered Deal" "Token Details" stage
     And I am presented with the "Please provide a vesting period" error message for the "Vested Period" field

--- a/cypress/integration/features/deals/partnered-deal/stage5.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage5.feature
@@ -13,7 +13,6 @@ Feature: "Token Details" stage (Stage 5)
       | Partnered Deal |
       | Make an offer  |
 
-
   # Scenario: Token Details - Address
   # Scenario: Token Details - Amount
   # Scenario: Token Details - Instant Transfer Set up
@@ -49,13 +48,19 @@ Feature: "Token Details" stage (Stage 5)
 
   #####################################################
 
+  Scenario: Validation - Proceeding when unsaved data
+    Given I want to fill in information for the "Primary DAO Tokens" section
+    And I fill in the "Token amount" field with "123"
+    When I try to proceed to next step
+    Then I am notified, that I am unable to proceed due to validation errors
+    Then I am presented with the "Partnered Deal" "Token Details" stage
+
   Scenario: Validates required fields
     When I try to proceed to next step
     Then I am presented with the "Partnered Deal" "Token Details" stage
     And I am presented with the "Address is required" error message for the "Token address" field
     And I am presented with the "Amount is required" error message for the "Token amount" field
     And I am presented with the "Execution period is required" error message for the "Execution Period" field
-
 
   Scenario: Validates vesting fields
     When I try to proceed to next step
@@ -78,6 +83,4 @@ Feature: "Token Details" stage (Stage 5)
     Then I am presented with the "Partnered Deal" "Token Details" stage
     And I am presented with the "Please provide a vesting period" error message for the "Vested Period" field
     And I am presented with the "Please provide a cliff period" error message for the "Cliff Period" field
-
-  # Scenario: Validation - Proceeding when unsaved data
 

--- a/cypress/integration/features/deals/partnered-deal/submitStage.feature
+++ b/cypress/integration/features/deals/partnered-deal/submitStage.feature
@@ -2,7 +2,6 @@ Feature: Submit Stage - Open Deal (Partnered Deal)
   Scenario: View registration data
     # Then all the wizard registration data should be presented
 
-  @focus
   Scenario: Prevent navigation - Direct navigation
     Given I navigate to the "Partnered Deal" "Submit" stage
     Then I should be redirected to the Home Page

--- a/cypress/integration/tests/deals/terms.e2e.ts
+++ b/cypress/integration/tests/deals/terms.e2e.ts
@@ -40,6 +40,10 @@ Given("I add content to the first Clause", () => {
   Terms.getClausesTextarea().first().type(UPDATED);
 });
 
+Given("I add content to the last Clause", () => {
+  Terms.getClausesTextarea().last().type(UPDATED);
+});
+
 Given("I have {int} existing Clause(s)", (numOfClauses: number) => {
   Terms.getClauses().should("have.length", 1);
 
@@ -62,7 +66,19 @@ When("I save the changes to the first Clause", () => {
   });
 });
 
-When("I delete the latest Clause", () => {
+When("I save the changes to the last Clause", () => {
+  Terms.getClauses().last().within(() => {
+    EditingCard.click("Save");
+  });
+});
+
+When("I edit the last Clause", () => {
+  Terms.getClauses().last().within(() => {
+    EditingCard.click("Edit");
+  });
+});
+
+When("I delete the last Clause", () => {
   Terms.getClauses().last().within(() => {
     EditingCard.click("Delete");
   });
@@ -118,4 +134,10 @@ Then("the Clause's content should be cleared", () => {
 
 Then("I cannot delete the Clause", () => {
   EditingCard.getButton("Delete").should("not.exist");
+});
+
+Then("the first Clause should be in View mode", () => {
+  Terms.getClauses().first().within(() => {
+    EditingCard.getButton("Edit").should("be.visible");
+  });
 });

--- a/cypress/integration/tests/deals/token-details.e2e.ts
+++ b/cypress/integration/tests/deals/token-details.e2e.ts
@@ -9,7 +9,7 @@ Given("I add a Token Details form", () => {
   });
 });
 
-Given(/^I have (\d+) Token Details forms? for the "(.*)"$/, (numOfForms: number) => {
+Given("I have {int} Token Details forms?", (numOfForms: number) => {
   withinWizardSection().within(() => {
     cy.get("[data-test='tokenDetails']").should("have.length", 1);
 
@@ -21,9 +21,12 @@ Given(/^I have (\d+) Token Details forms? for the "(.*)"$/, (numOfForms: number)
   });
 });
 
-When(/^I try to save the Token Details form for the "(.*)"$/, () => {
+When("I try to save the Token Details form", () => {
   withinWizardSection().within(() => {
     cy.get("[data-test='saveTokenDetail']").click();
+
+    cy.get("[data-test='loadingIcon']").should("be.visible");
+    cy.get("[data-test='loadingIcon']").should("not.exist");
   });
 
 });
@@ -40,7 +43,7 @@ Then("I can delete a Token Details form", () => {
   cy.get("[data-test='deleteTokenDetail']").should("have.length", 2);
 });
 
-And(/the Token Details form was not saved for the "(.*)"$/, () => {
+And("the Token Details form was not saved", () => {
   withinWizardSection().within(() => {
     cy.get("[data-test='saveTokenDetail']").should("be.visible");
   });

--- a/cypress/integration/tests/deals/token-details.e2e.ts
+++ b/cypress/integration/tests/deals/token-details.e2e.ts
@@ -1,0 +1,47 @@
+import { And, Given, Then, When } from "@badeball/cypress-cucumber-preprocessor/methods";
+import { withinWizardSection } from "../../common/deal-wizard";
+
+Given("I add a Token Details form", () => {
+  withinWizardSection().within(() => {
+    cy.contains("button", "Add token").click();
+
+    cy.get("[data-test='tokenDetails']").should("have.length.greaterThan", 0);
+  });
+});
+
+Given(/^I have (\d+) Token Details forms? for the "(.*)"$/, (numOfForms: number) => {
+  withinWizardSection().within(() => {
+    cy.get("[data-test='tokenDetails']").should("have.length", 1);
+
+    for (let i = 1; i < numOfForms; i += 1) {
+      cy.contains("button", "Add token").click();
+    }
+
+    cy.get("[data-test='tokenDetails']").should("have.length", numOfForms);
+  });
+});
+
+When(/^I try to save the Token Details form for the "(.*)"$/, () => {
+  withinWizardSection().within(() => {
+    cy.get("[data-test='saveTokenDetail']").click();
+  });
+
+});
+
+Then("I am presented with an empty Token Details form", () => {
+  cy.get("[data-test='tokenDetails']").should("be.visible");
+});
+
+Then("I cannot delete a Token Details form", () => {
+  cy.get("[data-test='deleteTokenDetail']").should("be.not.exist");
+});
+
+Then("I can delete a Token Details form", () => {
+  cy.get("[data-test='deleteTokenDetail']").should("have.length", 2);
+});
+
+And(/the Token Details form was not saved for the "(.*)"$/, () => {
+  withinWizardSection().within(() => {
+    cy.get("[data-test='saveTokenDetail']").should("be.visible");
+  });
+});

--- a/cypress/integration/tests/deals/token-details.e2e.ts
+++ b/cypress/integration/tests/deals/token-details.e2e.ts
@@ -9,7 +9,7 @@ Given("I add a Token Details form", () => {
   });
 });
 
-Given("I have {int} Token Details forms?", (numOfForms: number) => {
+Given("I have {int} Token Details form(s)", (numOfForms: number) => {
   withinWizardSection().within(() => {
     cy.get("[data-test='tokenDetails']").should("have.length", 1);
 
@@ -25,7 +25,6 @@ When("I try to save the Token Details form", () => {
   withinWizardSection().within(() => {
     cy.get("[data-test='saveTokenDetail']").click();
 
-    cy.get("[data-test='loadingIcon']").should("be.visible");
     cy.get("[data-test='loadingIcon']").should("not.exist");
   });
 

--- a/src/resources/elements/primeDesignSystem/pbutton/pbutton.html
+++ b/src/resources/elements/primeDesignSystem/pbutton/pbutton.html
@@ -2,7 +2,7 @@
   <button class="${type} ${fullWidth?'full-width':''} ${noAnimation? 'no-animation': ''}" disabled.bind="disabled" role="button">
     <slot></slot>
     <span class="icon ${isLoading? 'is-loading': ''}">
-      <i if.bind="isLoading" class="spinner fas fa-sync-alt"></i>
+      <i data-test="loadingIcon" if.bind="isLoading" class="spinner fas fa-sync-alt"></i>
     </span>
   </button>
 </template>

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
@@ -1,4 +1,4 @@
-<template>
+<template data-test="tokenDetails">
   <pcard>
     <div if.bind="viewMode === 'edit'">
 
@@ -104,11 +104,11 @@
       </pform-input>
 
       <div class="tokenDetailsFooter">
-        <pbutton if.bind="!hideDeleteButton" class="deleteButton" click.delegate="onDelete()" type="tertiary">
+        <pbutton if.bind="!hideDeleteButton" class="deleteButton" click.delegate="onDelete()" type="tertiary" data-test="deleteTokenDetail">
           Delete
           <i class="fa fa-trash"></i>
         </pbutton>
-        <pbutton click.delegate="save()" is-loading.bind="saving" type="primary">Save</pbutton>
+        <pbutton click.delegate="save()" is-loading.bind="saving" type="primary" data-test="saveTokenDetail">Save</pbutton>
       </div>
     </div>
 

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
@@ -9,7 +9,6 @@
         label="Token Address"
         label-info="Make sure to use the native contract address of the token.">
         <pinput-text
-          input.trigger="getTokenInfo(token.address)"
           placeholder="0x..."
           validation-state.bind="tokenInfoLoading? 'validating': addressInput.validationState !== 'validating' ? addressInput.validationState : undefined"
           value.bind="token.address & validate"
@@ -40,8 +39,8 @@
               src.bind="token.logoURI">
           </p>
           <pform-input input-reference.bind="logoImageInput">
-            <pinput-text input.trigger="checkURL()" value.bind="token.logoURI & validate"
-              view-model.ref="logoImageInput"></pinput-text>
+            <pinput-text value.bind="token.logoURI & validate"
+                         view-model.ref="logoImageInput"></pinput-text>
           </pform-input>
         </div>
       </div>

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
@@ -75,9 +75,10 @@
           <div class="vesting-input">
             <p>Tokens vested for</p>
             <pform-input data-test="proposal-vested-period-field" input-reference.bind="vestedForInput">
-              <pinput-group disabled.bind="token.amount.toString() === token.instantTransferAmount.toString()">
+              <pinput-group
+                disabled.bind="!token.amount || token.amount.toString() === token.instantTransferAmount.toString()">
                 <pinput-numeric
-                  disabled.bind="token.amount.toString() === token.instantTransferAmount.toString()"
+                  disabled.bind="!token.amount || token.amount.toString() === token.instantTransferAmount.toString()"
                   not-wei
                   value.bind="token.vestedFor | secondsDays & validate"
                   view-model.ref="vestedForInput"></pinput-numeric>
@@ -88,9 +89,10 @@
           <div class="vesting-input">
             <p>with a cliff of</p>
             <pform-input data-test="proposal-cliff-period-field" input-reference.bind="cliffOfInput">
-              <pinput-group disabled.bind="token.amount.toString() === token.instantTransferAmount.toString()">
+              <pinput-group
+                disabled.bind="!token.amount || token.amount.toString() === token.instantTransferAmount.toString()">
                 <pinput-numeric
-                  disabled.bind="token.amount.toString() === token.instantTransferAmount.toString()"
+                  disabled.bind="!token.amount || token.amount.toString() === token.instantTransferAmount.toString()"
                   not-wei
                   value.bind="token.cliffOf | secondsDays & validate"
                   view-model.ref="cliffOfInput"></pinput-numeric>

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
@@ -153,8 +153,12 @@ export class TokenDetails {
         this.token.cliffOf = undefined;
       }
     });
-    this.aureliaHelperService.createPropertyWatch(this.token, "address", () => {
+    this.aureliaHelperService.createPropertyWatch(this.token, "address", address => {
       this.token.amount = undefined;
+      this.getTokenInfo(address);
+    });
+    this.aureliaHelperService.createPropertyWatch(this.token, "logoURI", () => {
+      this.checkURL();
     });
   }
 

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
@@ -57,11 +57,7 @@ export class TokenDetails {
   }
 
   async attached() {
-    // Add the validation rules only for deals that are not Open Proposals
-    if (![WizardType.editOpenProposal, WizardType.createOpenProposal].includes(this.wizardType)) {
-      this.addValidation();
-    }
-
+    this.addValidation();
     this.watchTokenProperties();
 
     this.viewMode = this.viewMode ?? "edit";

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
@@ -68,8 +68,8 @@ export class TokenDetails {
       }
     });
 
-    if (this.token.address) {
-      await this.getTokenInfo(this.token.address);
+    if (this.token.address && (this.token.logoURI || this.token.name || this.token.decimals || this.token.symbol)) {
+      this.showTokenDetails = true;
     }
   }
 

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
@@ -42,6 +42,7 @@ export class TermsStage implements IBaseWizardStage {
 
     this.termClauses.splice(index, 1);
     this.wizardState.registrationData.terms.clauses.splice(index, 1);
+    this.stageMetadata.termsViewModes.splice(index, 1);
   }
 
   addClause() {

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
@@ -24,7 +24,7 @@
           token.bind="token"
           view-model.ref="primaryDAOTokenDetails[$index]"
           wizard-type.bind="wizardType"
-          hide-delete-button.bind="wizardState.registrationData.primaryDAO.tokens.length === 1"
+          hide-delete-button.bind="wizardState.registrationData.primaryDAO.tokens.length === 1 && !isOpenProposalWizard"
         ></token-details>
 
         <pbutton class="addTokenButton" click.delegate="addToken(wizardState.registrationData.primaryDAO.tokens)"
@@ -61,7 +61,7 @@
           view-mode.bind="stageMetadata.partnerDAOTokenDetailsViewModes[$index]"
           token.bind="token"
           view-model.ref="partnerDAOTokenDetails[$index]"
-          hide-delete-button.bind="wizardState.registrationData.partnerDAO.tokens.length === 1"
+          hide-delete-button.bind="wizardState.registrationData.partnerDAO.tokens.length === 1 && !isOpenProposalWizard"
         ></token-details>
 
         <pbutton class="addTokenButton" click.delegate="addToken(wizardState.registrationData.partnerDAO.tokens)"

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
@@ -7,7 +7,7 @@
 
     <div class="stageSection" data-test="primary-dao-tokens">
       <div class="stageSectionSidebar">
-        <h2 class="sidebarHeader heading heading3 title">
+        <h2 class="sidebarHeader heading heading3 title" data-test="section-title">
           <template if.bind="isOpenProposalWizard">Tokens</template>
           <template else>Primary DAO Tokens</template>
         </h2>
@@ -82,7 +82,7 @@
 
     <div class="stageSection">
       <div class="stageSectionSidebar">
-        <h2 class="sidebarHeader heading heading3 title">Execution Period</h2>
+        <h2 class="sidebarHeader heading heading3 title" data-test="section-title">Execution Period</h2>
         <p class="sidebarText">
           After both parties have discussed and agreed on the deal clauses they should be ready to fully fund the deal and execute the swap on-chain.
         </p>

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
@@ -18,7 +18,7 @@
       <div class="stageSectionContent">
         <token-details
           repeat.for="token of wizardState.registrationData.primaryDAO.tokens"
-          on-delete.call="deleteToken(token, wizardState.registrationData.primaryDAO.tokens, primaryDAOTokenDetails)"
+          on-delete.call="deleteToken($index, wizardState.registrationData.primaryDAO.tokens, primaryDAOTokenDetails, stageMetadata.primaryDAOTokenDetailsViewModes)"
           on-saved.call="checkedForUnsavedChanges()"
           view-mode.bind="stageMetadata.primaryDAOTokenDetailsViewModes[$index]"
           token.bind="token"
@@ -56,7 +56,7 @@
       <div class="stageSectionContent">
         <token-details
           repeat.for="token of wizardState.registrationData.partnerDAO.tokens"
-          on-delete.call="deleteToken(token, wizardState.registrationData.partnerDAO.tokens, partnerDAOTokenDetails)"
+          on-delete.call="deleteToken($index, wizardState.registrationData.partnerDAO.tokens, partnerDAOTokenDetails, stageMetadata.partnerDAOTokenDetailsViewModes)"
           on-saved.call="checkedForUnsavedChanges()"
           view-mode.bind="stageMetadata.partnerDAOTokenDetailsViewModes[$index]"
           token.bind="token"

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
@@ -6,8 +6,9 @@ import "./tokenDetailsStage.scss";
 import { IDAO, IDealRegistrationTokenSwap, IToken } from "../../../../entities/DealRegistrationTokenSwap";
 import { areFormsValid } from "../../../../services/ValidationService";
 import { TokenDetails } from "../../components/tokenDetails/tokenDetails";
+import { ViewMode } from "../../../../resources/elements/editingCard/editingCard";
 
-type TokenDetailsMetadata = Record<"primaryDAOTokenDetailsViewModes" | "partnerDAOTokenDetailsViewModes", ("edit" | "view")[]>;
+type TokenDetailsMetadata = Record<"primaryDAOTokenDetailsViewModes" | "partnerDAOTokenDetailsViewModes", ViewMode[]>;
 
 @autoinject
 export class TokenDetailsStage {
@@ -106,12 +107,10 @@ export class TokenDetailsStage {
     this.checkedForUnsavedChanges();
   }
 
-  deleteToken(token: IToken, tokens: IToken[], forms: TokenDetails[]): void {
-    const index = tokens.indexOf(token);
-    if (index !== -1) {
-      forms.splice(index, 1);
-      tokens.splice(index, 1);
-    }
+  deleteToken(index: number, tokens: IToken[], forms: TokenDetails[], tokensViewModes: ViewMode[]): void {
+    forms.splice(index, 1);
+    tokens.splice(index, 1);
+    tokensViewModes.splice(index, 1);
     this.checkedForUnsavedChanges();
   }
 

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
@@ -104,7 +104,6 @@ export class TokenDetailsStage {
       decimals: 18,
       logoURI: "",
     });
-    this.checkedForUnsavedChanges();
   }
 
   deleteToken(index: number, tokens: IToken[], forms: TokenDetails[], tokensViewModes: ViewMode[]): void {
@@ -137,7 +136,7 @@ export class TokenDetailsStage {
   }
 
   private isCreatingPartneredDealLike(wizardType: WizardType): boolean {
-    return [WizardType.createPartneredDeal, WizardType.makeAnOffer].includes(wizardType);
+    return [WizardType.createPartneredDeal, WizardType.makeAnOffer, WizardType.editPartneredDeal].includes(wizardType);
   }
 
   private isCreatingDealLike(wizardType: WizardType): boolean {


### PR DESCRIPTION
## What was done
- 337 fixed issues where deleting a token detail card or a term clause, the newly created card had the wrong view mode
   - e2e for clause case
- 408 edit partner deal should have token details prefilled
   - no dedicated e2e, because 2 other cases covered by "Scenario Outline: Add a default empty form, when there is no Token" (Create Partnered Deal, and Make an Offer)
- fixed firefox related issue with binding to value
- don't re-fetch token when switching back and forth in token details stage

#### Before
(Explained in the connected issue)
