### PR TITLE
#386 - Update dashboard status colors

### DIFF
--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -5,6 +5,7 @@
   <require from="./dealClauses/dealClauses"></require>
   <require from="./dealDiscussion/dealDiscussion"></require>
   <require from="./dealDescription/dealDescription"></require>
+  <require from="../deals/timeLeft/timeLeft"></require>
 
   <main class="page animated-page au-animate dealDashboardContainer">
     <deal-menubar deal.bind="deal"></deal-menubar>
@@ -15,7 +16,12 @@
       </h1>
 
       <let deal-privacy-text="${deal.registrationData.isPrivate ? 'Private' : 'Public'}"></let>
-      <h2 data-test="dealStatus">• ${deal.status}, Recently updated (${dealPrivacyText})</h2>
+      <h2 data-test="dealStatus">
+        <time-left deal.to-view="deal" hide-icons largest>
+          <span slot="before">•</span>
+          <span>(${dealPrivacyText})</span>
+        </time-left>
+      </h2>
     </section>
 
     <aside class="aside">

--- a/src/deals/timeLeft/timeLeft.html
+++ b/src/deals/timeLeft/timeLeft.html
@@ -13,7 +13,9 @@
       largest} left
       </div> -->
       <div class.bind="status">
+        <slot name="before"></slot>
         ${deal.status}
+        <slot></slot>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What was done
- update `<time-left>` with slots

## Testing
choose a deal from home page

#### Before
![image](https://user-images.githubusercontent.com/30693990/158913878-29a2be2d-70e9-4a40-add6-28aef63d0523.png)

#### After
![image](https://user-images.githubusercontent.com/30693990/158913852-605bfbfb-b346-4cd4-97b1-6fbc86186621.png)
