### PR TITLE
#414 - Token details wrong address still shows token information sub form

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -68,6 +68,10 @@ cy.get("[data-test='open-proposal-button']").click()
 cy.url().should("include", "deals/open");
 ```
 
+### Tags
+- `@focus` - only run focused Scenario in .feature file
+- `@regression` - Indicate Scenario is to cover a regression in the code
+
 ### Tooling
 - [VSCode Cucumber Autocomplete Extension](https://github.com/alexkrechik/VSCucumberAutoComplete#settings-example)
 

--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -19,6 +19,13 @@ const stageTitlesToURLs = {
 export let sectionTitle = "";
 
 export function withinWizardSection() {
+  if (sectionTitle === "") {
+    const sectionErrorMessage = "Please specify the section you are targeting in the Wizard.\n"
+      + "Use the following step:\n\n"
+      + "  Given I want to fill in information for the \"<sectionName>\" section";
+    throw Error(sectionErrorMessage);
+  }
+
   return cy.contains("[data-test='section-title']", sectionTitle).parents(".stageSection");
 }
 
@@ -40,6 +47,14 @@ When("I go to previous step", () => {
 
 When("I try to proceed to next step", () => {
   cy.get("[data-test='wizard-proceed-button']").click();
+});
+
+When("I use the stepper to go to the {string} step", (stepName: string) => {
+  cy.url().then(url => {
+    const oldUrl = url;
+    cy.contains("[data-test='pstepper-step-name']", stepName).click();
+    cy.url().should("not.equal", oldUrl);
+  });
 });
 
 When("I try to submit the registration data", () => {
@@ -99,8 +114,7 @@ Then("I am presented with the {string} {string} stage", (wizardTitle: keyof type
   cy.url().should("contain", `/initiate/token-swap/${wizardTitlesToURLs[wizardTitle]}/${stageTitlesToURLs[stageTitle]}`);
 });
 
-When("I fill in the {string} field with an invalid address", (field: string) => {
-  const invalidAddress = "invalid address";
+When("I fill in the {string} field with an invalid address {string}", (field: string, invalidAddress: string) => {
   withinWizardSection().within(() => {
     cy.get(`[data-test='proposal-${field.toLowerCase().replaceAll(" ", "-")}-field']`).within(() => {
       cy.get("input, textarea").type(invalidAddress);

--- a/cypress/integration/features/deals/open-proposal/stage5.feature
+++ b/cypress/integration/features/deals/open-proposal/stage5.feature
@@ -8,9 +8,23 @@ Feature: "Token Details" stage (Stage 5) - Open Proposal
   Scenario: Token Details - Optional
     Then I can proceed to the next step
 
+  #####################################################
+
+  @regression
+  Scenario: Token Details - Incorrect Address and navigation
+    Given I want to fill in information for the "Tokens" section
+    And I add a Token Details form
+    When I fill in the "Token address" field with an invalid address "0xE834627cDE2dC8F55Fe4a26741D3e91527A8a498"
+    And I am presented with the "Please enter a valid IERC20 address" error message for the "Token address" field
+    And I go to previous step
+    And I use the stepper to go to the "Token Details" step
+    Then I should not be presented with the Token Details metadata
+
+  #####################################################
+
   Scenario: Proceeding to the next stage - only Token Details
     Given I want to fill in information for the "Tokens" section
-    Given I add a Token Details form
+    And I add a Token Details form
     When I fill in the "Token address" field with "0x43D4A3cd90ddD2F8f4f693170C9c8098163502ad"
     And I fill in the "Token amount" field with "123"
     And I fill in the "Vested Period" field with "123"

--- a/cypress/integration/features/deals/partnered-deal/stage5.feature
+++ b/cypress/integration/features/deals/partnered-deal/stage5.feature
@@ -71,7 +71,7 @@ Feature: "Token Details" stage (Stage 5)
 
   Scenario: Validates if the wallet address has the correct format
     Given I want to fill in information for the "Primary DAO Tokens" section
-    When I fill in the "Token address" field with an invalid address
+    When I fill in the "Token address" field with an invalid address "invalid address"
     And I try to proceed to next step
     Then I am presented with the "Partnered Deal" "Token Details" stage
     And I am presented with the "Please enter a valid ethereum address" error message for the "Token address" field

--- a/cypress/integration/tests/deals/token-details.e2e.ts
+++ b/cypress/integration/tests/deals/token-details.e2e.ts
@@ -74,6 +74,10 @@ Then("the {string} field should not be disabled", (field: string) => {
   });
 });
 
+Then("I should not be presented with the Token Details metadata", () => {
+  cy.get("[data-test='tokenDetailsMetadata']").should("not.exist");
+});
+
 And("the Token Details form was not saved", () => {
   withinWizardSection().within(() => {
     cy.get("[data-test='saveTokenDetail']").should("be.visible");

--- a/src/entities/DealRegistrationTokenSwap.ts
+++ b/src/entities/DealRegistrationTokenSwap.ts
@@ -22,7 +22,7 @@ export interface IToken {
 
   name: string,
   symbol: string,
-  decimals: number | undefined,
+  decimals: number,
   logoURI: string,
 
   amount: string

--- a/src/entities/DealRegistrationTokenSwap.ts
+++ b/src/entities/DealRegistrationTokenSwap.ts
@@ -22,7 +22,7 @@ export interface IToken {
 
   name: string,
   symbol: string,
-  decimals: number,
+  decimals: number | undefined,
   logoURI: string,
 
   amount: string

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
@@ -14,7 +14,7 @@
           value.bind="token.address & validate"
           view-model.ref="addressInput"></pinput-text>
       </pform-input>
-      <div class="detailsTable" if.bind="showTokenDetails">
+      <div data-test="tokenDetailsMetadata" class="detailsTable" if.bind="showTokenDetails">
         <div class="detailsCell">
           <p>Name</p>
           <p if.bind="!tokenDetailsNotFound.name">${token.name}</p>


### PR DESCRIPTION
## What was done
remove default decimals
why?
- causes the bug (this was the quickest fix, else have to rethink logic when to show token details metadata)
- 413 says "The default of 18 is deprecated and will soon be replaced by an exception", so will be deprecated anyway? (that's why I chose this approach)
   - #421 removes the default decimals

## Testing

#### Before

#### After
should not show token metadata