### PR TITLE
#429 - Remove periods (".") from tooltips

### DIFF
--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.html
@@ -7,7 +7,7 @@
         helper-message.bind="tokenInfoLoading ? 'Searching token address details...': ''"
         input-reference.bind="addressInput"
         label="Token Address"
-        label-info="Make sure to use the native contract address of the token.">
+        label-info="Make sure to use the native contract address of the token">
         <pinput-text
           placeholder="0x..."
           validation-state.bind="tokenInfoLoading? 'validating': addressInput.validationState !== 'validating' ? addressInput.validationState : undefined"

--- a/src/wizards/tokenSwapDealWizard/stages/proposalStage/proposalStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/proposalStage/proposalStage.html
@@ -20,7 +20,7 @@
         <pform-input
           class="wizardFormInput wizardFormInputNarrow"
           label="Proposal Title"
-          label-info="Give a clear title to your proposal "
+          label-info="Give a clear title to your proposal"
           show-counter
           max-length="50"
           data-test="proposal-title-field">
@@ -30,7 +30,7 @@
         <pform-input
           class="wizardFormInput wizardFormInputNarrow"
           label="Proposal Summary"
-          label-info="Give a brief outline of the Token swap deal."
+          label-info="Give a brief outline of the Token swap deal"
           show-counter
           max-length="250"
           data-test="proposal-summary-field">
@@ -40,7 +40,7 @@
         <pform-input
           class="wizardFormInput wizardFormInputNarrow"
           label="Proposal Description"
-          label-info="Describe the details, background and features of your Token Swap proposal. Explain why it's valuable or unique."
+          label-info="Describe the details, background and features of your Token Swap proposal. Explain why it's valuable or unique"
           show-counter
           max-length="1000"
           data-test="proposal-description-field">


### PR DESCRIPTION
## What was done
1. searched for "ptooltip" -> all hits okay, but further checking label-info
1. searched for "label-info" -> some hits
2. searched for ." in .html files -> nothing
   
## Testing

#### Before

#### After
no more evil periods