### PR TITLE
422 - Privacy label depending on wizard type

### DIFF
--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -33,6 +33,10 @@ Given(/^I want to fill in information for the "(.*)" section$/, (_sectionTitle: 
   sectionTitle = _sectionTitle;
 });
 
+Given("I'm in the {string} stage", (stageTitle: string) => {
+  cy.contains("[data-test='pstepper-step']", stageTitle).click();
+});
+
 Then("I am presented the option to choose a partner", () => {
   cy.url().should("match", /(initiate\/token-swap$)/);
 });
@@ -103,6 +107,14 @@ Given("I edit a \"Partnered Deal\"", () => {
   const dealId = "partnered_deals_stream_hash_3";
   const url = `partnered-deal/${dealId}/edit/submit`;
   cy.visit(url);
+  cy.get("[data-test='stageHeaderTitle']", {timeout: 10000}).should("be.visible");
+});
+
+Given("I edit an \"Open Proposal\"", () => {
+  const dealId = "open_deals_stream_hash_1";
+  const url = `open-proposal/${dealId}/edit/submit`;
+  cy.visit(url);
+  cy.get("[data-test='stageHeaderTitle']", {timeout: 10000}).should("be.visible");
 });
 
 Then("I am presented with the {string} {string} stage", (wizardTitle: keyof typeof wizardTitlesToURLs, stageTitle: keyof typeof stageTitlesToURLs) => {

--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -78,7 +78,8 @@ Given("I navigate to the {string} {string} stage", (wizardTitle: keyof typeof wi
   if (wizardTitle === "Make an offer") {
     const dealId = "open_deals_stream_hash_1";
     const url = `make-an-offer/${dealId}/${stageTitlesToURLs[stageTitle]}`;
-    cy.visit(url).wait(1500);
+    cy.visit(url);
+    cy.get("[data-test='stageHeaderTitle']", {timeout: 10000}).should("be.visible");
     return;
   }
 

--- a/cypress/integration/features/deals/make-an-offer/stage2.feature
+++ b/cypress/integration/features/deals/make-an-offer/stage2.feature
@@ -1,0 +1,10 @@
+Feature: "Lead details" stage (Stage 2)
+
+  Background:
+    Given I navigate to the "Make an offer" "Lead Details" stage
+
+  @focus
+  Scenario: Proposal Lead - Disable, when Primary DAO keeps Admin rights
+    Given I want to fill in information for the "Proposal Lead" section
+    Then the "Proposal Lead Address" field should be disabled
+    And the "Contact Email" field should be disabled

--- a/cypress/integration/features/deals/make-an-offer/submit.feature
+++ b/cypress/integration/features/deals/make-an-offer/submit.feature
@@ -1,0 +1,7 @@
+Feature: Submit Stage - Make an offer
+
+  # @todo Uncomment, when have steps for going through whole registration wizard
+  # Scenario: Overview - Privacy label - Edit
+  #   Given I navigate to make an offer Primary DAO stage
+  #   And I'm in the "Submit" stage
+  #   Then the I should get the correct label "Make Deal Private" for the Privacy part

--- a/cypress/integration/features/deals/open-proposal/submit-edit.feature
+++ b/cypress/integration/features/deals/open-proposal/submit-edit.feature
@@ -1,0 +1,7 @@
+Feature: Submit Stage - Open Proposal
+
+  # @todo: Uncomment, when have steps for going through whole registration wizard
+  # Scenario: Overview - Privacy label - Edit
+  #   Given I edit an "Open Proposal"
+  #   And I'm in the "Submit" stage
+  #   Then the I should get the correct label "Make Offers Private" for the Privacy part

--- a/cypress/integration/features/deals/partnered-deal/submitStage.feature
+++ b/cypress/integration/features/deals/partnered-deal/submitStage.feature
@@ -2,6 +2,13 @@ Feature: Submit Stage - Open Deal (Partnered Deal)
   Scenario: View registration data
     # Then all the wizard registration data should be presented
 
+  # @todo: Uncomment, when have steps for going through whole registration wizard
+  # Scenario: Overview - Privacy label - Edit
+  #   Given I edit a "Partnered Deal"
+  #   And I'm in the "Submit" stage
+  #   Then the I should get the correct label "Make Deal Private" for the Privacy part
+
+
   Scenario: Prevent navigation - Direct navigation
     Given I navigate to the "Partnered Deal" "Submit" stage
     Then I should be redirected to the Home Page

--- a/cypress/integration/tests/deals/make-an-offer-wizard.e2e.ts
+++ b/cypress/integration/tests/deals/make-an-offer-wizard.e2e.ts
@@ -10,6 +10,7 @@ Given("I navigate to make an offer wizard", () => {
 
 Given("I navigate to make an offer Primary DAO stage", () => {
   cy.visit(`/make-an-offer/${proposalId}/primary-dao`);
+  cy.get("[data-test='stageHeaderTitle']", {timeout: 10000}).should("be.visible");
 });
 
 Then("I can see DAO details section with pre-filled disabled fields", () => {

--- a/cypress/integration/tests/deals/submit-stage.e2e.ts
+++ b/cypress/integration/tests/deals/submit-stage.e2e.ts
@@ -7,3 +7,8 @@ Then("all the wizard registration data should be presented", () => {
 Then("I should be notified, that the registration was successful", () => {
   cy.get("[data-test='congratulatePopup']").should("be.visible");
 });
+
+// Then("the I should get the correct label "Make Deal Private" for the Privacy part", () => {})
+Then("the I should get the correct label {string} for the Privacy part", (privacyLabelText: string) => {
+  cy.contains(".submitContentLabel", privacyLabelText).should("be.visible");
+});

--- a/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/leadDetailsStage/leadDetailsStage.html
@@ -6,7 +6,7 @@
 
     <div class="stageSection">
       <div class="stageSectionSidebar">
-        <h2 class="sidebarHeader heading heading3 title">Proposal Lead</h2>
+        <h2 data-test="section-title" class="sidebarHeader heading heading3 title">Proposal Lead</h2>
         <p class="sidebarText">Provide the Ethereum address for the Proposal Lead who will gain admin rights of the deal.</p>
         <p class="sidebarText">Proposal Leads can edit the deal during the negotiation to integrate new points emerging from the conversation. They can initiate the funding phase once a deal is approved and they can execute the token swap.</p>
         <p class="sidebarText">The Proposal Lead can be changed at any time until the deal is approved.</p>
@@ -17,7 +17,7 @@
           class="wizardFormInput"
           label="Proposal Lead Address"
           input-reference.bind="input"
-          data-test="proposal-wallet-address-field">
+          data-test="proposal-proposal-lead-address-field">
           <pinput-text
             disabled.bind="isMakeAnOfferWizardAndKeepsAdminRights"
             placeholder="0x..."
@@ -35,7 +35,7 @@
           Make Me the Proposal Lead
         </pbutton>
 
-        <pform-input class="wizardFormInput wizardFormInputNarrow" data-test="proposal-email-field"
+        <pform-input class="wizardFormInput wizardFormInputNarrow" data-test="proposal-contact-email-field"
                      label="Contact E-mail (optional)">
           <pinput-text disabled.bind="isMakeAnOfferWizardAndKeepsAdminRights"
                        value.bind="wizardState.registrationData.proposalLead.email & validate:form"></pinput-text>

--- a/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.html
@@ -78,7 +78,7 @@
         </section>
 
         <section class="stageSectionContent">
-          <div class="submitContentLabel">Private Offers</div>
+          <div class="submitContentLabel">${privacyText}</div>
           <div class="submitContent">
             <ptoggle value.bind="submitData.isPrivate" disabled></ptoggle>
           </div>

--- a/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.html
@@ -78,7 +78,10 @@
         </section>
 
         <section class="stageSectionContent">
-          <div class="submitContentLabel">${privacyText}</div>
+          <div class="submitContentLabel">
+            <template if.bind="isOpenProposalLike">Make Offers Private</template>
+            <template else>Make Deal Private</template>
+          </div>
           <div class="submitContent">
             <ptoggle value.bind="submitData.isPrivate" disabled></ptoggle>
           </div>

--- a/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.ts
@@ -13,7 +13,7 @@ export class SubmitStage {
   public wizardManager: WizardManager;
   public wizardState: IWizardState<IDealRegistrationTokenSwap>;
   private submitData: IDealRegistrationTokenSwap;
-  private privacyText: string;
+  private isOpenProposalLike = false;
 
   constructor(
     private wizardService: WizardService,
@@ -26,8 +26,8 @@ export class SubmitStage {
     this.wizardManager = stageMeta.wizardManager;
     this.wizardState = this.wizardService.getWizardState(this.wizardManager);
 
+    this.isOpenProposalLike = [WizardType.createOpenProposal, WizardType.editOpenProposal].includes(stageMeta.wizardType);
     this.submitData = this.wizardState.registrationData;
-    this.setPrivacyText(stageMeta.wizardType);
   }
 
   public async onSubmit(): Promise<void> {
@@ -47,24 +47,5 @@ export class SubmitStage {
     } catch (error) {
       this.eventAggregator.publish("handleFailure", `There was an error while creating the Deal: ${error}`);
     }
-  }
-
-  private setPrivacyText(wizardType: WizardType): void {
-    if (this.isPartneredDealLike(wizardType)) {
-      this.privacyText = "Make Deal Private";
-    } else if (this.isOpenProposalLike(wizardType)) {
-      this.privacyText = "Make Offers Private";
-    }
-  }
-
-  private isPartneredDealLike(wizardType: WizardType): boolean {
-    return [WizardType.createPartneredDeal, WizardType.makeAnOffer, WizardType.editPartneredDeal].includes(wizardType);
-  }
-
-  private isOpenProposalLike(wizardType: WizardType): boolean {
-    return [
-      WizardType.createOpenProposal,
-      WizardType.editOpenProposal,
-    ].includes(wizardType);
   }
 }

--- a/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.ts
@@ -4,7 +4,7 @@ import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { AlertService, IAlertModel } from "services/AlertService";
 import { FirestoreService } from "services/FirestoreService";
 import { IWizardState, WizardService } from "wizards/services/WizardService";
-import { IStageMeta } from "wizards/tokenSwapDealWizard/dealWizardTypes";
+import { IStageMeta, WizardType } from "wizards/tokenSwapDealWizard/dealWizardTypes";
 import { WizardManager } from "wizards/tokenSwapDealWizard/wizardManager";
 import "./submitStage.scss";
 
@@ -13,6 +13,7 @@ export class SubmitStage {
   public wizardManager: WizardManager;
   public wizardState: IWizardState<IDealRegistrationTokenSwap>;
   private submitData: IDealRegistrationTokenSwap;
+  private privacyText: string;
 
   constructor(
     private wizardService: WizardService,
@@ -26,6 +27,7 @@ export class SubmitStage {
     this.wizardState = this.wizardService.getWizardState(this.wizardManager);
 
     this.submitData = this.wizardState.registrationData;
+    this.setPrivacyText(stageMeta.wizardType);
   }
 
   public async onSubmit(): Promise<void> {
@@ -45,5 +47,24 @@ export class SubmitStage {
     } catch (error) {
       this.eventAggregator.publish("handleFailure", `There was an error while creating the Deal: ${error}`);
     }
+  }
+
+  private setPrivacyText(wizardType: WizardType): void {
+    if (this.isPartneredDealLike(wizardType)) {
+      this.privacyText = "Make Deal Private";
+    } else if (this.isOpenProposalLike(wizardType)) {
+      this.privacyText = "Make Offers Private";
+    }
+  }
+
+  private isPartneredDealLike(wizardType: WizardType): boolean {
+    return [WizardType.createPartneredDeal, WizardType.makeAnOffer, WizardType.editPartneredDeal].includes(wizardType);
+  }
+
+  private isOpenProposalLike(wizardType: WizardType): boolean {
+    return [
+      WizardType.createOpenProposal,
+      WizardType.editOpenProposal,
+    ].includes(wizardType);
   }
 }


### PR DESCRIPTION
## What was done
- e2e (for now disabled, because don't have full registration wizard flow yet
- change text based on wizard type

## Testing

#### Before

#### After
Open proposal
![image.png](https://images.zenhubusercontent.com/61d459cd2e1f45dd77990d23/906c9485-e0eb-454f-900f-9061085f1409)

Partnered 
![image.png](https://images.zenhubusercontent.com/61d459cd2e1f45dd77990d23/5ebdaf09-00f8-4dfc-bb53-83e14583af77)

and Make offer
![image.png](https://images.zenhubusercontent.com/61d459cd2e1f45dd77990d23/0e544a68-d7da-41d8-a285-adf2d8775b31)
