### PR TITLE
458 - Actions should not be visible when not a representative

### DIFF
--- a/src/dealDashboard/dealClauses/dealClauses.ts
+++ b/src/dealDashboard/dealClauses/dealClauses.ts
@@ -2,7 +2,7 @@ import { autoinject, bindingMode } from "aurelia-framework";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { DealTokenSwap } from "entities/DealTokenSwap";
 import { EthereumService } from "services/EthereumService";
-import { DiscussionsService } from "DealDashboard/discussionsService";
+import { DiscussionsService } from "dealDashboard/discussionsService";
 import { IClause } from "entities/DealRegistrationTokenSwap";
 import "./dealClauses.scss";
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -49,6 +49,7 @@
             index="${$index}"
             replies-to.bind="comment.replyTo ? (threadDictionary[comment.replyTo] ? threadDictionary[comment.replyTo] : deletedComment) : ''"
             replies-to-profile.bind="comment.replyTo ? (threadProfiles[threadDictionary[comment.replyTo].author]) : ''"
+            is-authorized.bind="isAuthorized && isMember"
             comment.bind="comment">
           </single-comment>
         </div>

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -67,11 +67,6 @@ export class DiscussionThread {
     return this.discussionsService.comments;
   }
 
-  @computedFrom("ethereumService.defaultAccountAddress")
-  private get checkIsAuthorized(): boolean {
-    return !!this.ethereumService.defaultAccountAddress;
-  }
-
   attached(): void {
     this.initialize();
     this.eventAggregator.subscribe("Network.Changed.Account", (): void => {
@@ -102,8 +97,6 @@ export class DiscussionThread {
 
   private async initialize(isIdChange = false): Promise<void> {
     this.isLoading.discussions = true;
-
-    this.isAuthorized = this.checkIsAuthorized;
 
     // Only member (representatives) can add a comments to a discussion
     this.isMember = (

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
@@ -21,7 +21,7 @@
         </div>
       </div>
       <div class="actions">
-        <div if.bind="comment.author !== connectedAddress && isConnected" class="vote action">
+        <div if.bind="comment.author !== connectedAddress && isAuthorized" class="vote action">
           <pbutton type="tertiary" 
             is-loading.bind="loading['isVoting ' + comment._id] && pressed.up"
             disabled.bind="loading['isVoting ' + comment._id]"
@@ -42,16 +42,16 @@
             &nbsp;<i class="fas fa-reply"></i>
           </pbutton>
         </div>
-        <div if.bind="!loading['isVoting ' + comment._id]" class="vote count ${isConnected ? 'isConnected' : ''}">
+        <div if.bind="!loading['isVoting ' + comment._id]" class="vote count ${isAuthorized ? 'isAuthorized' : ''}">
           <div class="${voteDirection}Vote">
             <i class="fas fa-thumbs-${voteDirection === 'no'? 'up':voteDirection}"></i>
             ${voteDirection === 'down' ? -votes : votes}
           </div>
         </div>
-        <div else class="vote count ${isConnected ? 'isConnected' : ''}">
+        <div else class="vote count ${isAuthorized ? 'isAuthorized' : ''}">
           <div type="tertiary"><i class="fas fa-thumbs-up"></i> <i class="spinner fas fa-circle-notch fa-spin"></i></div>
         </div>
-        <div if.bind="comment.author === connectedAddress && isConnected" class="vote action">
+        <div if.bind="comment.author === connectedAddress && isAuthorized" class="vote action">
           <pbutton type="tertiary" click.delegate="delete()">Delete</pbutton>
           <!-- Commenting out until `edit` is implemented in the convo.space -->
           <!-- <pbutton type="tertiary" disabled click.delegate="edit()">Edit</pbutton> -->
@@ -61,7 +61,7 @@
           </pbutton>
         </div>
       </div>
-      <time class="lastActivity ${isConnected ? 'isConnected' : ''}">${comment.lastModified}</time>
+      <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.lastModified}</time>
     </header>
 
     <section class="commentBody">

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.scss
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.scss
@@ -216,9 +216,9 @@
   }
 
   &:hover {
-    .actions>.vote.count.isConnected,
-    .lastActivity.isConnected,
-    .footer>.vote.count.isConnected {
+    .actions>.vote.count.isAuthorized,
+    .lastActivity.isAuthorized,
+    .footer>.vote.count.isAuthorized {
       display: none;
     }
     .actions>.vote.action,

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
@@ -21,11 +21,11 @@ export class SingleComment {
   @bindable private highlighted: number;
   @bindable private index: number;
   @bindable private isReply?: boolean = false;
-  @bindable commentAction;
+  @bindable private commentAction;
+  @bindable private isAuthorized = false;
 
   private connectedAddress: string;
   private dealClauseId: string;
-  private isConnected = false;
   private pressed = {
     up: false,
     down: false,
@@ -41,7 +41,6 @@ export class SingleComment {
   attached(): void {
     this.connectedAddress = this.ethereumService.defaultAccountAddress;
     this.dealClauseId = this.router.currentInstruction.params.discussionId;
-    this.isConnected = !!this.connectedAddress;
     this.comment.lastModified = this.dateService.formattedTime(parseInt(this.comment.createdOn)).diff();
     this.commentTimeInterval = setInterval((): void => {
       this.comment.lastModified = this.dateService.formattedTime(parseInt(this.comment.createdOn)).diff();


### PR DESCRIPTION
## What was done
Action buttons are not being shown on comment hover if the connected wallet is not of a representative.

Tests, implemented separately [here](https://github.com/PrimeDAO/prime-deals-dapp/blob/chore/e2e-wallet-mocking/cypress/integration/features/dealDashboard/discussions/discussions-single-comment-public-view.feature).