### PR TITLE
Renable discussions test with firebase

### DIFF
--- a/cypress/integration/common/navigate.ts
+++ b/cypress/integration/common/navigate.ts
@@ -16,6 +16,13 @@ export class E2eNavigation {
     const homePaths = ["/", "/home"];
     return homePaths.includes(pathName);
   }
+
+  public static hasAppLoaded() {
+    return cy.window().then((window) => {
+      const { pathname } = window.location;
+      return E2eNavigation.isHome(pathname);
+    });
+  }
 }
 
 Given("I navigate to the Deals home page", () => {

--- a/cypress/integration/common/navigate.ts
+++ b/cypress/integration/common/navigate.ts
@@ -20,7 +20,7 @@ export class E2eNavigation {
   public static hasAppLoaded() {
     return cy.window().then((window) => {
       const { pathname } = window.location;
-      return E2eNavigation.isHome(pathname);
+      return pathname !== "blank"; // Cypress returns "blank" if app not loaded yet
     });
   }
 }

--- a/cypress/integration/features/api/deal-api.feature
+++ b/cypress/integration/features/api/deal-api.feature
@@ -8,7 +8,7 @@
     ################
     # Given I'm the Proposal Lead of an Open Proposal
     # Given I create an Open Proposal
-
+#
     ##################
     # Partnered Deal
     ##################
@@ -18,3 +18,7 @@
     # Private Deal
     # Given I'm the Proposal Lead of an Open Proposal
     # Given I create a Private Partnered Deal
+
+  # Scenario: Login to app
+  #   Given I navigate to the Deals home page
+  #   And I connect to the wallet with address "0x45b211cd08724D584cD94e7B974584249cD87638"

--- a/cypress/integration/features/dealDashboard/discussions/discussions-privacy.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-privacy.feature
@@ -1,4 +1,4 @@
-Feature: Discussions - Wallet
+Feature: Discussions - Privacy
   Background:
     Given I'm the Proposal Lead of an Open Proposal
     And I'm viewing a private Deal

--- a/cypress/integration/features/dealDashboard/discussions/discussions-privacy.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-privacy.feature
@@ -4,7 +4,7 @@ Feature: Discussions - Wallet
     And I'm viewing a private Deal
 
   Scenario: Privacy - Public Viewer - No interaction
-    Given I'm a Connected Public user
+    Given I'm a "Connected Public" user
     Then I should not be able to see Discussions
     # ^ Note: Actually, should not be able to access deal dashboard at all, but for now at least have this test
 

--- a/cypress/integration/features/dealDashboard/discussions/discussions-single-comment-public-view.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-single-comment-public-view.feature
@@ -1,14 +1,13 @@
-# Feature: Discussions - Single Comment - Public View
-  # @todo uncomment once have e2e firebase seed
-  # Scenario: Single comments - Actions - Don't show actions not connected to a wallet
-  #   Given I'm not connected to a wallet
-  #   And I choose a single Topic with replies
-  #   When I view a single Comment
-  #   Then I should not see the Comment actions
+Feature: Discussions - Single Comment - Public View
+  Scenario Outline: Single comments - Actions - Don't show actions
+    Given I'm a "<UserType>" user
+    And the Open Proposal has Discussions
+    And I'm viewing the Open Proposal
 
-  # @todo uncomment once have e2e firebase seed
-  # Scenario: Single comments - Actions - Don't show actions if not a representative
-  #   Given I connect to the wallet with address "0x0000000000000000000000000000000000000000"
-  #   And I choose a single Topic with replies
-  #   When I view a single Comment
-  #   Then I should not see the Comment actions
+    And I choose a single Topic with replies
+    Then I should not see the Comment actions
+
+    Examples:
+      | UserType         |
+      | Anonymous        |
+      | Connected Public |

--- a/cypress/integration/features/dealDashboard/discussions/discussions-single-comment.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-single-comment.feature
@@ -1,6 +1,7 @@
 Feature: Discussions - Single Comment
   Background:
     Given I'm the Proposal Lead of an Open Proposal
+    And the Open Proposal has Discussions
     And I'm viewing the Open Proposal
     And I choose a single Topic with replies
 
@@ -9,15 +10,13 @@ Feature: Discussions - Single Comment
   # Scenario: Single comments - Create (disabled)
   # Scenario: Single comments - Activity
 
-  # @todo uncomment once have e2e firebase seed
-  # Scenario: Single comments - Like
-  #   When I view a single Comment
-  #   Then I can like that Comment
+  Scenario: Single comments - Like
+    When I view a single Comment
+    Then I can like that Comment
 
-  # @todo uncomment once have e2e firebase seed
-  # Scenario: Single comments - Like - Cannot like own comment
-  #   When I view my own Comment
-  #   Then I cannot like my own Comment
+  Scenario: Single comments - Like - Cannot like own comment
+    When I view my own Comment
+    Then I cannot like my own Comment
 
   # Scenario: Single comments - Like - Disables other buttons
   # Scenario: Single comments - Dislike
@@ -27,12 +26,11 @@ Feature: Discussions - Single Comment
   # Scenario: Single comments - Delete - Replied to
   # Scenario: Single comments - Delete - Only mine
 
-  # @todo uncomment once have e2e firebase seed
-  # Scenario: Single comments - Reply
-  #   When I view a single Comment
-  #   Then I can reply to that Comment
-  #   And I can see who I am replying to
-  #   And I can cancel replying that Comment again
+  Scenario: Single comments - Reply
+    When I view a single Comment
+    Then I can reply to that Comment
+    And I can see who I am replying to
+    And I can cancel replying that Comment again
 
   # TODO: This scenario is covered by "Scenario: Single comments - Reply"
   #   But should have it's own test.

--- a/cypress/integration/features/dealDashboard/discussions/discussions-wallet.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-wallet.feature
@@ -1,9 +1,9 @@
 Feature: Discussions - Wallet
   Background:
     Given I'm an "Anonymous" user
-    And I'm viewing an Open Proposal
+    And the Open Proposal has Discussions
+    And I'm viewing the Open Proposal
 
-  @focus
   Scenario: Wallet - Disconnected - Deal Clauses
     Then I cannot begin a Discussion
 
@@ -11,7 +11,7 @@ Feature: Discussions - Wallet
     Then I'm informed about who can participate in Discussions
 
   Scenario: Wallet - Disconnected - Single Comments - Add Comment
-    When I choose a single Topic without replies
+    When I choose a single Topic with replies
     Then I cannot add a Comment
 
   Scenario: Wallet - Disconnected - Single Comments - Comment actions
@@ -20,3 +20,6 @@ Feature: Discussions - Wallet
     And I cannot reply to a Comment
     # And I cannot dislike a Comment
   #   - no vote, comment, reply, (dis)like
+
+# TODO do we need test for?
+# When I choose a single Topic with replies

--- a/cypress/integration/features/dealDashboard/discussions/discussions-wallet.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-wallet.feature
@@ -1,6 +1,6 @@
 Feature: Discussions - Wallet
   Background:
-    Given I'm an Anonymous user
+    Given I'm an "Anonymous" user
     And I'm viewing an Open Proposal
 
   @focus

--- a/cypress/integration/features/deals/open-proposal/create-open-proposal.feature
+++ b/cypress/integration/features/deals/open-proposal/create-open-proposal.feature
@@ -1,7 +1,7 @@
 Feature: Create Open Proposal
   Background:
     Given I navigate to the "Open proposal" "Proposal" stage
-    And I'm a Connected Public user
+    And I'm a "Connected Public" user
 
   @user_journey
   Scenario: Create Open Proposal

--- a/cypress/integration/tests/dealDashboard/discussion.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/discussion.e2e.ts
@@ -1,5 +1,7 @@
-import { And, Then, When } from "@badeball/cypress-cucumber-preprocessor/methods";
+import { And, Given, Then, When } from "@badeball/cypress-cucumber-preprocessor/methods";
+import { E2eDealsApi } from "../../common/deal-api";
 import { PAGE_LOADING_TIMEOUT } from "../../common/test-constants";
+import { E2eDeals } from "../deals/deals.e2e";
 import { E2eWallet } from "../wallet.e2e";
 
 interface ICommentOptions {
@@ -125,6 +127,18 @@ export class E2eDiscussion {
       .find("[data-test='comment-input-button'] button");
   }
 }
+
+Given("the Open Proposal has Discussions", () => {
+  E2eDealsApi.getOpenProposals({isLead: true}).then(deals => {
+    const dealWithDiscussions = deals.find(deal => Object.keys(deal.clauseDiscussions ?? {}).length > 0);
+    if (dealWithDiscussions === undefined) {
+      throw new Error("[TEST] Did not find any Open Proposals with discussions.");
+    }
+
+    E2eDeals.currentDeal = dealWithDiscussions.registrationData;
+    E2eDeals.currentDealId = dealWithDiscussions.id;
+  });
+});
 
 When("I choose a single Topic without replies", () => {
   E2eDiscussion

--- a/cypress/integration/tests/dealDashboard/discussion.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/discussion.e2e.ts
@@ -129,7 +129,7 @@ export class E2eDiscussion {
 }
 
 Given("the Open Proposal has Discussions", () => {
-  E2eDealsApi.getOpenProposals({isLead: true}).then(deals => {
+  E2eDealsApi.getOpenProposals({isLead: E2eWallet.isLead}).then(deals => {
     const dealWithDiscussions = deals.find(deal => Object.keys(deal.clauseDiscussions ?? {}).length > 0);
     if (dealWithDiscussions === undefined) {
       throw new Error("[TEST] Did not find any Open Proposals with discussions.");


### PR DESCRIPTION
## What was done
- re-enable 5 tests related to discussions and access check (eg. disable actions when not connected)

## Testing

#### Before

#### After
![image](https://user-images.githubusercontent.com/30693990/161390228-431ea0de-954b-4fdb-b38d-74afbca7f633.png)
