### PR TITLE
510 - Refac carousel selector css

### DIFF
--- a/src/deals/list/deals.html
+++ b/src/deals/list/deals.html
@@ -34,7 +34,7 @@
       <i class="spinner fa fas fa-circle-notch fa-spin"></i>
     </div>
     <div class="section deal-carousel" if.to-view="!featuredDeals || featuredDeals.length">
-      <div class="heading02Gradient selector">
+      <div class="heading02Gradient carousel-selector">
         <span if.to-view="isTabVisible(0,showMine,ethereumService.defaultAccountAddress)"
           data-test="open-proposals-tab"
           class="selector-tab ${cardIndex==0?'active':''}"

--- a/src/deals/list/deals.scss
+++ b/src/deals/list/deals.scss
@@ -66,54 +66,6 @@ pbutton button.secondary {
         }
       }
     }
-    &.deal-carousel {
-      margin-bottom: 100px;
-      .scrollerContainer {
-        margin-bottom: 28px;
-
-        .scroller {
-          deal-summary {
-            margin-right: $spacing-normal * 2;
-
-            &:last-child {
-              margin-right: 0;
-            }
-          }
-        }
-      }
-
-      > .carousel-selector {
-        display: flex;
-        -webkit-text-fill-color: $Neutral02;
-        border-bottom: 2px solid $Border01;
-        width: 100%;
-        transition: background 1s ease-in-out;
-        margin-bottom: 53px;
-        font-family: Aeonik;
-
-        :not(:first-child) {
-          margin-left: 63px;
-        }
-
-        > .selector-tab {
-          cursor: pointer;
-
-          &:hover:not(.active) {
-            -webkit-text-fill-color: $Neutral04;
-          }
-        }
-
-        > .active {
-          background: $Gradient02;
-          -webkit-text-fill-color: transparent;
-          -webkit-background-clip: text;
-          background-clip: text;
-          border-bottom: 6px solid;
-          @include border-gradient($Gradient02);
-          padding-bottom: 19px;
-        }
-      }
-    }
 
     &.all-deals {
       .grid {

--- a/src/deals/list/deals.scss
+++ b/src/deals/list/deals.scss
@@ -82,7 +82,7 @@ pbutton button.secondary {
         }
       }
 
-      > .selector {
+      > .carousel-selector {
         display: flex;
         -webkit-text-fill-color: $Neutral02;
         border-bottom: 2px solid $Border01;

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -23,7 +23,7 @@
       </div>
 
       <!-- Deals Carousel -->
-      <div class="section deals" if.to-view="!featuredDeals || featuredDeals.length">
+      <div class="section deal-carousel" if.to-view="!featuredDeals || featuredDeals.length">
         <div class="heading02Gradient carousel-selector">
           <span if.to-view="allDeals.open.length"
             data-test="open-proposals-tab"

--- a/src/home/home.html
+++ b/src/home/home.html
@@ -24,7 +24,7 @@
 
       <!-- Deals Carousel -->
       <div class="section deals" if.to-view="!featuredDeals || featuredDeals.length">
-        <div class="heading02Gradient selector">
+        <div class="heading02Gradient carousel-selector">
           <span if.to-view="allDeals.open.length"
             data-test="open-proposals-tab"
             class="selector-tab ${cardIndex==0?'active':''}"

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -70,7 +70,7 @@
         }
       }
 
-      > .selector {
+      >.carousel-selector {
         display: flex;
         -webkit-text-fill-color: $Neutral02;
         border-bottom: 2px solid $Border01;
@@ -209,7 +209,7 @@
       }
 
       &.deals {
-        .selector {
+        .carousel-selector {
           margin-bottom: 20px;
 
           :not(:first-child) {

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -4,7 +4,7 @@
 
 .page.home {
   .section {
-    &.deals {
+    &.deal-carousel {
       margin-bottom: 64px;
     }
     &.hero {
@@ -55,7 +55,7 @@
       }
     }
 
-    &.deals {
+    &.deal-carousel {
       .scrollerContainer {
         margin-bottom: 28px;
 
@@ -176,7 +176,7 @@
 }
 
 @media screen and (max-width: 900px) and (min-width: 550px) {
-  .deals {
+  .deal-carousel {
     padding: 0 45px;
   }
 }
@@ -208,7 +208,7 @@
         }
       }
 
-      &.deals {
+      &.deal-carousel {
         .carousel-selector {
           margin-bottom: 20px;
 

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -4,9 +4,6 @@
 
 .page.home {
   .section {
-    &.deal-carousel {
-      margin-bottom: 64px;
-    }
     &.hero {
       margin-bottom: 16px;
     }
@@ -52,79 +49,6 @@
         justify-content: start;
         cursor: pointer;
         gap: 40px;
-      }
-    }
-
-    &.deal-carousel {
-      .scrollerContainer {
-        margin-bottom: 28px;
-
-        .scroller {
-          deal-summary {
-            margin-right: $spacing-normal * 2;
-
-            &:last-child {
-              margin-right: 0;
-            }
-          }
-        }
-      }
-
-      >.carousel-selector {
-        display: flex;
-        -webkit-text-fill-color: $Neutral02;
-        border-bottom: 2px solid $Border01;
-        width: 100%;
-        transition: background 1s ease-in-out;
-        font-family: Aeonik;
-        margin-bottom: 40px;
-
-        :not(:first-child) {
-          margin-left: 63px;
-        }
-
-        > .selector-tab {
-          cursor: pointer;
-
-          &:hover:not(.active) {
-            -webkit-text-fill-color: $Neutral04;
-          }
-        }
-
-        > .active {
-          background: $Gradient02;
-          -webkit-text-fill-color: transparent;
-          -webkit-background-clip: text;
-          background-clip: text;
-          border-bottom: 6px solid;
-          @include border-gradient($Gradient02);
-          padding-bottom: 19px;
-        }
-      }
-
-      > .dealsButton {
-        margin-top: 28px;
-        margin-bottom: 150px;
-
-        button.tertiary {
-          color: $Neutral03;
-          opacity: 0.3;
-          transition: 0.2s;
-
-          &:hover {
-            opacity: 1;
-          }
-        }
-      }
-
-      .loading {
-        text-align: center;
-        font-size: 32px;
-        padding-top: 24px;
-
-        i {
-          color: $Secondary07;
-        }
       }
     }
 
@@ -175,12 +99,6 @@
   }
 }
 
-@media screen and (max-width: 900px) and (min-width: 550px) {
-  .deal-carousel {
-    padding: 0 45px;
-  }
-}
-
 @media screen and (max-width: $PageBreakWidth) {
   .page.home {
     .section {
@@ -205,40 +123,6 @@
           align-items: center;
           margin-bottom: 80px;
           gap: 28px;
-        }
-      }
-
-      &.deal-carousel {
-        .carousel-selector {
-          margin-bottom: 20px;
-
-          :not(:first-child) {
-            margin-left: 20px;
-          }
-
-          .selector-tab {
-            font-size: $font-size3;
-          }
-        }
-
-        .scrollerContainer {
-          margin-bottom: 0;
-
-          .scroller deal-summary {
-            margin: 0;
-
-            &:not(:last-child) {
-              margin-bottom: 20px;
-            }
-
-            .dealSummary {
-              text-align: left;
-            }
-          }
-        }
-
-        .dealsButton {
-          margin-bottom: 80px;
         }
       }
 

--- a/src/resources/elements/primeDesignSystem/_carousel.scss
+++ b/src/resources/elements/primeDesignSystem/_carousel.scss
@@ -1,0 +1,120 @@
+@import "src/styles/colors.scss";
+@import "./variables";
+@import "./colors";
+
+.deal-carousel {
+  margin-bottom: 64px;
+
+  .scrollerContainer {
+    margin-bottom: 28px;
+
+    .scroller {
+      deal-summary {
+        margin-right: $spacing-normal * 2;
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+
+  > .carousel-selector {
+    display: flex;
+    -webkit-text-fill-color: $Neutral02;
+    border-bottom: 2px solid $Border01;
+    width: 100%;
+    transition: background 1s ease-in-out;
+    font-family: Aeonik;
+    margin-bottom: 40px;
+
+    :not(:first-child) {
+      margin-left: 63px;
+    }
+
+    > .selector-tab {
+      cursor: pointer;
+
+      &:hover:not(.active) {
+        -webkit-text-fill-color: $Neutral04;
+      }
+    }
+
+    > .active {
+      background: $Gradient02;
+      -webkit-text-fill-color: transparent;
+      -webkit-background-clip: text;
+      background-clip: text;
+      border-bottom: 6px solid;
+      @include border-gradient($Gradient02);
+      padding-bottom: 19px;
+    }
+  }
+
+  > .dealsButton {
+    margin-top: 28px;
+    margin-bottom: 150px;
+
+    button.tertiary {
+      color: $Neutral03;
+      opacity: 0.3;
+      transition: 0.2s;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
+
+  .loading {
+    text-align: center;
+    font-size: 32px;
+    padding-top: 24px;
+
+    i {
+      color: $Secondary07;
+    }
+  }
+}
+
+@media screen and (max-width: 900px) and (min-width: 550px) {
+  .deal-carousel {
+    padding: 0 45px;
+  }
+}
+
+@media screen and (max-width: $PageBreakWidth) {
+  .deal-carousel {
+    .carousel-selector {
+      margin-bottom: 20px;
+
+      :not(:first-child) {
+        margin-left: 20px;
+      }
+
+      .selector-tab {
+        font-size: $font-size3;
+      }
+    }
+
+    .scrollerContainer {
+      margin-bottom: 0;
+
+      .scroller deal-summary {
+        margin: 0;
+
+        &:not(:last-child) {
+          margin-bottom: 20px;
+        }
+
+        .dealSummary {
+          text-align: left;
+        }
+      }
+    }
+
+    .dealsButton {
+      margin-bottom: 80px;
+    }
+  }
+}

--- a/src/resources/elements/primeDesignSystem/_styles.scss
+++ b/src/resources/elements/primeDesignSystem/_styles.scss
@@ -1,3 +1,4 @@
+@import "./carousel";
 @import "./pinput";
 @import "./typography";
 


### PR DESCRIPTION
## What was done
- Rename classes to better identify what is common
- move into `_carousel.scss`
    - Note: Design systems call it "Tab switcher", but since code used "carousel" I stick with that for now

## Testing
Clicking around a bit on
1. Home page
2. All Deals

Verification: 
Below are the mobile views for Home and All Deals.
I included this, because before, All Deals was not mobile responsive
--> Quick way to show, that both pages use the same styling now

#### Before
Not mobile friendly (big header)
![image](https://user-images.githubusercontent.com/30693990/161606902-4a5909ac-ca3f-4f68-b286-b4485c3f32de.png)


#### After
Mobile friendly (smaller header)

Left: Home page
Right: All Deals

![image](https://user-images.githubusercontent.com/30693990/161606829-e1916717-5159-423a-9020-bd702d7ac537.png)
