### PR TITLE
490 - chore(webpack): disable hash for local dev

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,9 +91,9 @@ module.exports = ( { production, extractCss, analyze, tests, hmr, port, host, } 
   output: {
     path: outDir,
     publicPath: baseUrl,
-    filename: production ? '[name].[chunkhash].bundle.js' : '[name].[fullhash].bundle.js',
+    filename: production ? '[name].[chunkhash].bundle.js' : '[name].bundle.js',
     sourceMapFilename: production ? '[name].[chunkhash].bundle.map' : undefined,
-    chunkFilename: production ? '[name].[chunkhash].chunk.js' : '[name].[fullhash].chunk.js'
+    chunkFilename: production ? '[name].[chunkhash].chunk.js' : '[name].chunk.js'
   },
   optimization: {
     runtimeChunk: true,  // separates the runtime chunk, required for long term cacheability


### PR DESCRIPTION
## What was done
Tested a week or so, and ram usage now hovering around 1gb (instead of up to 4.5)

## Testing
- run local dev
- do quite a few local changes

#### Before
- webpack ramps up ram

#### After
okay