### PR TITLE
chore(cypress): add defintion to tsconfig

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     // "strict": true,
     "types": [
-      "cypress"
+      "cypress",
+      "../src/definitions"
     ],
     "paths": {
       "services/*": ["../src/services/*"],


### PR DESCRIPTION
## What was done
- Utils.cloneDeep uses `structuredClone` (only available in node17) --> also add defintion to cypress

## Testing
run any cypress gui test
#### Before
error

#### After
ok