### PR TITLE
414 - Token details sub form wrong address

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -140,8 +140,11 @@ Through internal code ([App Actions](app_action)), we can access, eg. Firebase a
 
 ### Tags
 - `@focus` - only run focused Scenario in .feature file
-- `@regression` - Indicate Scenario is to cover a regression in the code
-- `@user_journey` - Larger in scope than usual Scenarios. Captures the "user journey" to achieve more complex interactions
+- `@regression` - Indicate Scenario is to cover a regression in the
+  code ([regression in programming](https://en.wiktionary.org/wiki/regression): The reappearance of a bug in a piece of
+  software that had previously been fixed.)
+- `@user_journey` - Larger in scope than usual Scenarios. Captures the "user journey" to achieve more complex
+  interactions
 - `@flaky` - indicate underlying test is flaky (eg. unstable - sometimes green, sometimes red)
 
 ### Tooling

--- a/cypress/integration/common/deal-wizard.ts
+++ b/cypress/integration/common/deal-wizard.ts
@@ -142,6 +142,11 @@ When("I fill in the {string} field with {string}", (field: WizardField, value: s
   E2eDealWizard.fillIn(value);
 });
 
+When("I change the {string} field by adding {string}", (field: WizardField, value: string) => {
+  E2eDealWizard.inField(field);
+  E2eDealWizard.addToField(value);
+});
+
 And("I wait until the Token has loaded", () => {
   waitForTokenAddressLoaded();
 });

--- a/cypress/integration/common/pageObjects/dealWizard.ts
+++ b/cypress/integration/common/pageObjects/dealWizard.ts
@@ -83,6 +83,17 @@ export class E2eDealWizard {
     return this;
   }
 
+  static addToField(value: string) {
+    cy.then(() => {
+      withinWizardSection().within(() => {
+        cy.get(`[data-test='${this.fieldTitle.toLowerCase().replaceAll(" ", "-")}-field']`).last().within(() => {
+          cy.get("input, textarea").type(value);
+        });
+      });
+    });
+    return this;
+  }
+
   public static getConnectToGetWallet() {
     return cy.get("[data-test='connect-to-get-wallet']");
   }

--- a/cypress/integration/features/deals/open-proposal/stage5-token-address.feature
+++ b/cypress/integration/features/deals/open-proposal/stage5-token-address.feature
@@ -1,0 +1,24 @@
+Feature: "Token Details" stage (Stage 5) - Token Address
+  Background:
+    Given I navigate to the "Open proposal" "Token Details" stage
+    Given I want to fill in information for the "Tokens" section
+    And I add a Token Details form
+
+  @regression
+  Scenario: Token Details - Incorrect Address and navigation
+    When I fill in the "Token address" field with an invalid address "0xE834627cDE2dC8F55Fe4a26741D3e91527A8a498"
+    And I am presented with the "Please enter a valid IERC20 address" error message for the "Token address" field
+    And I go to previous step
+    And I use the stepper to go to the "Token Details" step
+    Then I should not be presented with the Token Details metadata
+
+  @regression
+  Scenario: Token Details - Change Address and navigation
+    #                                              v E2E_ADDRESSES.PrimaryDAOToken
+    Given I fill in the "Token address" field with "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad"
+    And I wait until the Token has loaded
+    When I change the "Token address" field by adding "x"
+    And I am presented with the "Please enter a valid ethereum address" error message for the "Token address" field
+    And I go to previous step
+    And I use the stepper to go to the "Token Details" step
+    Then I should not be presented with the Token Details metadata

--- a/cypress/integration/features/deals/open-proposal/stage5.feature
+++ b/cypress/integration/features/deals/open-proposal/stage5.feature
@@ -10,18 +10,6 @@ Feature: "Token Details" stage (Stage 5) - Open Proposal
 
   #####################################################
 
-  @regression
-  Scenario: Token Details - Incorrect Address and navigation
-    Given I want to fill in information for the "Tokens" section
-    And I add a Token Details form
-    When I fill in the "Token address" field with an invalid address "0xE834627cDE2dC8F55Fe4a26741D3e91527A8a498"
-    And I am presented with the "Please enter a valid IERC20 address" error message for the "Token address" field
-    And I go to previous step
-    And I use the stepper to go to the "Token Details" step
-    Then I should not be presented with the Token Details metadata
-
-  #####################################################
-
   Scenario: Proceeding to the next stage - only Token Details
     Given I want to fill in information for the "Tokens" section
     And I add a Token Details form

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     // "strict": true,
     "types": [
-      "cypress"
+      "cypress",
+      "../src/definitions"
     ],
     "paths": {
       "services/*": ["../src/services/*"],

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
@@ -16,6 +16,7 @@ import { formatEther } from "ethers/lib/utils";
 import { NumberService } from "../../../../services/NumberService";
 import { PrimeRenderer } from "../../../../resources/elements/primeDesignSystem/validation/primeRenderer";
 import { WizardType } from "../../dealWizardTypes";
+import { ConsoleLogService } from "services/ConsoleLogService";
 
 @autoinject
 export class TokenDetails {
@@ -41,6 +42,7 @@ export class TokenDetails {
 
   constructor(
     private aureliaHelperService: AureliaHelperService,
+    private consoleLogService: ConsoleLogService,
     private tokenService: TokenService,
     private numberService: NumberService,
     private validationControllerFactory: ValidationControllerFactory,
@@ -78,6 +80,14 @@ export class TokenDetails {
     this.tokenInfoLoading = true;
     this.validTokenLogoURI = true;
 
+    /**
+     * Default to resetting Token information upon change of address
+     */
+    this.token.name = undefined;
+    this.token.logoURI = undefined;
+    this.token.symbol = undefined;
+    this.token.decimals = TokenService.DefaultDecimals;
+
     if (!Utils.isAddress(address) || !await this.tokenService.isERC20Token(address)) {
       this.tokenInfoLoading = false;
       return;
@@ -102,10 +112,7 @@ export class TokenDetails {
       this.token.decimals = tokenInfo.decimals ?? TokenService.DefaultDecimals;
       this.token.logoURI = tokenInfo.logoURI;
     } catch (error) {
-      this.token.name = undefined;
-      this.token.logoURI = undefined;
-      this.token.symbol = undefined;
-      this.token.decimals = TokenService.DefaultDecimals;
+      this.consoleLogService.logMessage(error.message, "error");
     }
 
     this.tokenDetailsNotFound.name = !this.token.name;
@@ -171,6 +178,8 @@ export class TokenDetails {
   }
 
   private addValidation() {
+    if (this.form.errors.length > 0) return;
+
     const rules = this.getValidationRules();
 
     this.form.addObject(this.token, rules);

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.ts
@@ -178,8 +178,6 @@ export class TokenDetails {
   }
 
   private addValidation() {
-    if (this.form.errors.length > 0) return;
-
     const rules = this.getValidationRules();
 
     this.form.addObject(this.token, rules);


### PR DESCRIPTION
## What was done
fix(tokenDetails): always reset token details 

Reason: 
- make sense upon address change to always reset

Background: 
- 414 still shows token details, despite wrong address

Cause:
- Code did not reset Token details on address guard

## Testing

#### Before

#### After
form always resets (and persists the reset) on stage change