### PR TITLE
Implement deals observability

### DIFF
--- a/firebaseFunctions/src/index.ts
+++ b/firebaseFunctions/src/index.ts
@@ -74,7 +74,7 @@ export const updateDealStructure = functions.firestore
     const batch = firestore.batch();
 
     const dealUpdates: Partial<IDealTokenSwapDocument> = {
-      modifiedAt: new Date().toISOString(),
+      // modifiedAt: new Date().toISOString(),
     };
 
     // If registration data was updated and the update was done to field/fields other than the privacy flag
@@ -128,7 +128,7 @@ export const onVoteUpdate = functions.firestore
       dealRef,
       {
         votingSummary,
-        modifiedAt: new Date().toISOString(),
+        // modifiedAt: new Date().toISOString(),
       },
       {merge: true}, // merges provided object with the existing data
     );

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -96,7 +96,6 @@ export class DealTokenSwap implements IDeal {
   }
 
   private initializedPromise: Promise<void>;
-  private dealDocument: IDealTokenSwapDocument;
   private now: Date;
 
   public id: IDealIdType;
@@ -104,6 +103,7 @@ export class DealTokenSwap implements IDeal {
   public totalPrice?: number;
   public initializing = true;
   public corrupt = false;
+  public dealDocument: IDealTokenSwapDocument;
 
   /**
    * the id used by the TokenSwapModule contract to identify this this.  Is

--- a/src/playground/firebasePlayground/firebaseDummyData.ts
+++ b/src/playground/firebasePlayground/firebaseDummyData.ts
@@ -20,7 +20,7 @@ export const openProposalDummyData1 = {
     "tokens": [
       {
         "symbol": "D2D",
-        "amount": null,
+        "amount": "30000000000000",
         "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
         "vestedFor": 864000,
         "logoURI": "https://assets.coingecko.com/coins/images/21609/thumb/RJD82RrV_400x400.jpg?1639559164",
@@ -41,7 +41,7 @@ export const openProposalDummyData1 = {
   "terms": {
     "clauses": [
       {
-        "id": "",
+        "id": "HFcE73RvJP5dG3cXVKZRJw",
         "text": "A clause asd",
       },
     ],
@@ -66,7 +66,7 @@ export const partnerDealDummyData1 = {
     "tokens": [
       {
         "symbol": "D2D",
-        "amount": null,
+        "amount": "20000000000000",
         "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
         "vestedFor": 864000,
         "logoURI": "https://assets.coingecko.com/coins/images/21609/thumb/RJD82RrV_400x400.jpg?1639559164",
@@ -96,7 +96,7 @@ export const partnerDealDummyData1 = {
     "tokens": [
       {
         "symbol": "D2D",
-        "amount": null,
+        "amount": "10000000000000",
         "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
         "vestedFor": 8640000,
         "logoURI": "https://assets.coingecko.com/coins/images/21609/thumb/RJD82RrV_400x400.jpg?1639559164",
@@ -116,7 +116,7 @@ export const partnerDealDummyData1 = {
   "terms": {
     "clauses": [
       {
-        "id": "",
+        "id": "0QSWgDPVF6971GTymndrqs",
         "text": "Clause one",
       },
     ],

--- a/src/services/DataSourceDealsTypes.ts
+++ b/src/services/DataSourceDealsTypes.ts
@@ -1,8 +1,10 @@
+import { Observable } from "rxjs";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { IDealDiscussion } from "entities/DealDiscussions";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { IDealTokenSwapDocument } from "./../entities/IDealTypes";
 import { Address } from "./EthereumService";
+import { IDocumentUpdates } from "./FirestoreTypes";
 
 export type IDealIdType = string;
 
@@ -34,6 +36,11 @@ export abstract class IDataSourceDeals {
   getDeals<TDealDocument extends IDealTokenSwapDocument>(accountAddress?: Address): Promise<Array<TDealDocument>> {
     throw new Error("Method not implemented.");
   }
+
+  getDealsObservables(accountAddress?: Address): Promise<Observable<IDocumentUpdates<IDealTokenSwapDocument>>> {
+    throw new Error("Method not implemented.");
+  }
+
   /**
    * add new vote or update existing
    * @param dealId

--- a/src/services/DataSourceDealsTypes.ts
+++ b/src/services/DataSourceDealsTypes.ts
@@ -37,7 +37,7 @@ export abstract class IDataSourceDeals {
     throw new Error("Method not implemented.");
   }
 
-  getDealsObservables(accountAddress?: Address): Promise<Observable<IDocumentUpdates<IDealTokenSwapDocument>>> {
+  getDealsObservables(accountAddress: Address, skipFirst = false): Promise<Observable<IDocumentUpdates<IDealTokenSwapDocument>>> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -97,10 +97,11 @@ export class DealService {
         StartingBlockNumber = 0;
         break;
     }
-    this.eventAggregator.subscribe("Network.Changed.Account", (): void => {
+    this.eventAggregator.subscribe("Network.Changed.Account", async (): Promise<void> => {
       if (!this.initializing) {
         try {
           this.eventAggregator.publish("deals.loading", true);
+          await this.getDeals();
           this.observeDeals();
         } finally {
           this.eventAggregator.publish("deals.loading", false);
@@ -137,14 +138,14 @@ export class DealService {
           }
 
           /**
-           * note this change will propogage instantly
+           * note this change will instantly propogate across the app, any dependencies on dealDocument
            */
           for (const dealDoc of updates.modified) {
             dealsMap.get(dealDoc.id).dealDocument = dealDoc;
           }
 
           /**
-           * now the deletes will propagate
+           * now the deletions will propagate
            */
           this.deals = dealsMap;
         }

--- a/src/services/FirestoreDealsService.ts
+++ b/src/services/FirestoreDealsService.ts
@@ -5,8 +5,9 @@ import { IDataSourceDeals } from "./DataSourceDealsTypes";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { Address } from "services/EthereumService";
-import { IFirebaseDocument } from "services/FirestoreTypes";
+import { IDocumentUpdates, IFirebaseDocument } from "services/FirestoreTypes";
 import { ConsoleLogService } from "services/ConsoleLogService";
+import { Observable } from "rxjs";
 
 @autoinject
 export class FirestoreDealsService<
@@ -20,6 +21,21 @@ export class FirestoreDealsService<
 
   public initialize(): void {
     throw new Error("Method not implemented.");
+  }
+
+  public async getDealsObservables(accountAddress?: Address): Promise<Observable<IDocumentUpdates<IDealTokenSwapDocument>>> {
+    await this.firestoreService.ensureAuthenticationIsSynced();
+
+    if (accountAddress) {
+      if (!this.isUserAuthenticated(accountAddress)) {
+        return;
+      }
+      this.consoleLogService.logMessage(`getting all deals observable for user ${accountAddress}`);
+      return this.firestoreService.allDealsForAddressObservable(accountAddress);
+    } else {
+      this.consoleLogService.logMessage("getting all public deals observable");
+      return this.firestoreService.allPublicDealsUpdatesObservable();
+    }
   }
 
   public async getDeals<TDealDocument>(accountAddress?: Address): Promise<Array<TDealDocument>> {

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -17,9 +17,9 @@ import {
 } from "firebase/firestore";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { firebaseAuth, firebaseDatabase, FirebaseService } from "./FirebaseService";
-import { combineLatest, fromEventPattern, Observable, Subject } from "rxjs";
+import { combineLatest, fromEventPattern, merge, Observable, Subject } from "rxjs";
 import { map, mergeAll } from "rxjs/operators";
-import { DEALS_TOKEN_SWAP_COLLECTION, IFirebaseDocument } from "./FirestoreTypes";
+import { DEALS_TOKEN_SWAP_COLLECTION, IDocumentUpdates, IFirebaseDocument } from "./FirestoreTypes";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import axios from "axios";
 import { IDealDiscussion } from "entities/DealDiscussions";
@@ -262,13 +262,25 @@ export class FirestoreService<
     return deals;
   }
 
+  public allDealsForAddressObservable(accountAddress: string): Observable<IDocumentUpdates<IDealTokenSwapDocument>> {
+    const allPublicDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.allPublicDealsQuery());
+    const representativeDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.representativeDealsQuery(accountAddress));
+    const proposalLeadDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.proposalLeadDealsQuery(accountAddress));
+
+    return merge(
+      allPublicDeals,
+      representativeDeals,
+      proposalLeadDeals,
+    );
+  }
+
   /**
    * Observes all public deals in Firestore
    *
    * @returns Observable<IFirebaseDocument<TDealDocument>[]>
    */
-  public subscribeToAllPublicDeals(): Observable<Array<IFirebaseDocument>> {
-    return this.getObservableOfQuery<Array<IFirebaseDocument>>(this.allPublicDealsQuery());
+  public allPublicDealsUpdatesObservable(): Observable<IDocumentUpdates<IDealTokenSwapDocument>> {
+    return this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.allPublicDealsQuery());
   }
 
   /**
@@ -418,6 +430,32 @@ export class FirestoreService<
     return query(
       collection(firebaseDatabase, DEALS_TOKEN_SWAP_COLLECTION),
       where("registrationData.proposalLead.address", "==", address),
+    );
+  }
+
+  private getObservableOfQueryUpdates<T>(q: Query<DocumentData>): Observable<IDocumentUpdates<T>> {
+    return fromEventPattern(
+      (handler) => onSnapshot(
+        q,
+        (querySnapshot: QuerySnapshot<DocumentData>) => {
+          const updatedDocuments = {
+            modified: [],
+            removed: [],
+          };
+          querySnapshot.docChanges().forEach((change) => {
+            if (change.type === "added" || change.type === "modified") {
+              updatedDocuments.modified.push(change.doc.data());
+            }
+            if (change.type === "removed") {
+              updatedDocuments.removed.push(change.doc.data());
+            }
+          });
+          handler(updatedDocuments);
+        },
+      ),
+      (handler, unsubscribe: Unsubscribe) => {
+        unsubscribe();
+      },
     );
   }
 }

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -18,7 +18,7 @@ import {
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { firebaseAuth, firebaseDatabase, FirebaseService } from "./FirebaseService";
 import { combineLatest, fromEventPattern, merge, Observable, Subject } from "rxjs";
-import { map, mergeAll } from "rxjs/operators";
+import { map, mergeAll, skip } from "rxjs/operators";
 import { DEALS_TOKEN_SWAP_COLLECTION, IDocumentUpdates, IFirebaseDocument } from "./FirestoreTypes";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import axios from "axios";
@@ -262,10 +262,16 @@ export class FirestoreService<
     return deals;
   }
 
-  public allDealsForAddressObservable(accountAddress: string): Observable<IDocumentUpdates<IDealTokenSwapDocument>> {
-    const allPublicDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.allPublicDealsQuery());
-    const representativeDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.representativeDealsQuery(accountAddress));
-    const proposalLeadDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.proposalLeadDealsQuery(accountAddress));
+  public allDealsForAddressObservable(accountAddress: string, skipFirst = false): Observable<IDocumentUpdates<IDealTokenSwapDocument>> {
+    const allPublicDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.allPublicDealsQuery()).pipe(
+      skip(skipFirst ? 1 : 0),
+    );
+    const representativeDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.representativeDealsQuery(accountAddress)).pipe(
+      skip(skipFirst ? 1 : 0),
+    );
+    const proposalLeadDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.proposalLeadDealsQuery(accountAddress)).pipe(
+      skip(skipFirst ? 1 : 0),
+    );
 
     return merge(
       allPublicDeals,

--- a/src/services/FirestoreTypes.ts
+++ b/src/services/FirestoreTypes.ts
@@ -4,3 +4,8 @@ export interface IFirebaseDocument<T = any> {
   id: string;
   data: T;
 }
+
+export interface IDocumentUpdates<T> {
+  modified: Array<T>,
+  removed: Array<T>,
+}


### PR DESCRIPTION
## What was done
After deals are initially loaded a subscription to deal updates is initiated.

**NOTE:** even though DealService is updated with new deals, the UI doesn't refresh automatically, so for example you have to go from all deals page to deal dashboard to actually see the updated deal

NOTE 2: Update to firebase functions: I've commented out code updating `modifiedAt` field because it was triggering multiple updates on the frontend pointlessly. That field is not used anywhere at the moment, but if we want it, we should look into a solution.

NOTE3: At the moment, deals in `this.deals` Map in `DealService` are updated more often than they should, because updates from firebase are emitted from 3 separate queries and sometimes deals are duplicated in those queries. Something to optimise. Suggestions welcomed

## Testing
- Adding new deals, changing deals registration data, votes.

#### Before
- Deals created/edited outside of the current browser tab, were not reflected in the app (without a refresh)

#### After
- Deals created/edited outside of the current browser tab are reflected in the UI