### PR TITLE
602 - Discussions firebase rules permissions (change to any auth'ed user)

### DIFF
--- a/cypress/fixtures/dealFixtures.ts
+++ b/cypress/fixtures/dealFixtures.ts
@@ -1,4 +1,4 @@
-import { IDealRegistrationTokenSwap } from "../../src/entities/DealRegistrationTokenSwap";
+import { IDealRegistrationTokenSwap, IRepresentative } from "../../src/entities/DealRegistrationTokenSwap";
 
 function getRandomId (){
   /**
@@ -122,6 +122,11 @@ export class DealDataBuilder {
   public withPrimaryDaoData = this.withFactory("primaryDAO");
   public withPartnerDaoData = this.withFactory("partnerDAO", PARTNER_DAO_DATA);
   public withTermsData = this.withFactory("terms");
+
+  public withPrimaryDaoRepresentative(newRepresentatives: Array<IRepresentative>) {
+    this.deal.primaryDAO.representatives.push(...newRepresentatives);
+    return this;
+  }
 
   private withFactory<DealKey extends keyof IDealRegistrationTokenSwap>(
     key: DealKey,

--- a/cypress/integration/common/deal-api.ts
+++ b/cypress/integration/common/deal-api.ts
@@ -133,6 +133,13 @@ export class E2eDealsApi {
     });
   }
 
+  /**
+   * Either: (via FirestoreService)
+   * 1. Init app bootstrapping and create a Deal
+   * 2. Just create a Deal
+   *
+   * Then set it to E2eDeals (for further testing usage)
+   */
   public static createDeal(
     registrationData: IDealRegistrationTokenSwap,
     options: IDealOptions = defaultDealOptions,
@@ -162,10 +169,10 @@ export class E2eDealsApi {
        * 2. Interact with Firestore
        */
       return cy.then(async () => {
-        const firestoreDealsService = E2eDealsApi.getDealService();
-        await firestoreDealsService.ensureAuthenticationIsSynced();
+        const firestoreService = E2eDealsApi.getDealService();
+        await firestoreService.ensureAuthenticationIsSynced();
 
-        const createdDeal = await firestoreDealsService.createDealTokenSwap(registrationData);
+        const createdDeal = await firestoreService.createDealTokenSwap(registrationData);
 
         E2eDeals.setDeal(createdDeal);
 

--- a/cypress/integration/common/deal-common.ts
+++ b/cypress/integration/common/deal-common.ts
@@ -8,6 +8,16 @@ import { E2eDealWizard } from "./pageObjects/dealWizard";
 import { PAGE_LOADING_TIMEOUT } from "./test-constants";
 
 export class E2EDashboard {
+  static visitDeal(dealId?: string) {
+    if (!dealId) {
+      dealId = E2eDeals.currentDealId;
+    }
+
+    const url = `deal/${dealId}`;
+    cy.visit(url);
+
+    cy.get(".dealDashboardContainer", {timeout: PAGE_LOADING_TIMEOUT}).should("be.visible");
+  }
   public static editDeal() {
     cy.contains("pbutton", "Edit deal").click();
 
@@ -27,18 +37,24 @@ After(() => {
 Given("I'm viewing the/an Open Proposal", () => {
   cy.then(() => {
     if (E2eDeals.currentDealId) {
-      const url = `deal/${E2eDeals.currentDealId}`;
-      cy.visit(url);
-
-      cy.get(".dealDashboardContainer", {timeout: PAGE_LOADING_TIMEOUT}).should("be.visible");
+      E2EDashboard.visitDeal();
       return;
     }
 
     E2eDealsApi.getFirstOpenProposalId({isLead: true}).then(dealId => {
-      const url = `deal/${dealId}`;
-      cy.visit(url);
+      E2EDashboard.visitDeal(dealId);
+    });
+  });
+});
 
-      cy.get(".dealDashboardContainer", {timeout: PAGE_LOADING_TIMEOUT}).should("be.visible");
+Given("I'm viewing a new public Open Proposal", () => {
+  cy.then(() => {
+    if (!E2eDeals.currentDeal) {
+      E2eDeals.currentDeal = MINIMUM_OPEN_PROPOSAL;
+    }
+
+    E2eDealsApi.createDeal(E2eDeals.currentDeal).then((createdDeal) => {
+      E2EDashboard.visitDeal(createdDeal.id);
     });
   });
 });

--- a/cypress/integration/features/dealDashboard/discussions/discussions-create.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-create.feature
@@ -1,13 +1,20 @@
 Feature: Discussions create
-  Background:
-    Given I'm a Connected Public user
-    And I create an Open Proposal
-
   @focus
-  Scenario: Creating a Discussion - No Discussions for Clause yet
-    When I'm viewing the Open Proposal
+  Scenario Outline: Creating a Discussion - No Discussions for Clause yet
+    Given I'm a "<UserType>" user
+    And I'm viewing a new public Open Proposal
     Then I should be informed of no discussions
     And I can create a new Discussion
+    And I'm informed about, that the discussion has no comments yet
+
+    Examples:
+      | UserType         |
+      | Connected Public |
+      | Proposal Lead    |
+      | Representative    |
+      #   v Covered by discussions-wallet. TODO: how to organize/track?
+      # | Anonymous        |
+
 
   Scenario: Creating a Discussion - Info text
     # This discussion has no comments yet

--- a/cypress/integration/features/dealDashboard/discussions/discussions-single-comment-public-view.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-single-comment-public-view.feature
@@ -4,8 +4,8 @@ Feature: Discussions - Single Comment - Public View
     And the Open Proposal has Discussions with replies
     And I'm viewing the Open Proposal
 
-    # And I choose a single Topic with replies
-    # Then I should not see the Comment actions
+    And I choose a single Topic with replies
+    Then I should not see the Comment actions
 
     Examples:
       | UserType         |

--- a/cypress/integration/tests/dealDashboard/discussion.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/discussion.e2e.ts
@@ -272,3 +272,7 @@ And("I cannot reply to a Comment", () => {
 
   cy.log("todo");
 });
+
+Then("I'm informed about, that the discussion has no comments yet", () => {
+  E2eDiscussion.waitForNoCommentsText();
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,20 +23,20 @@ service cloud.firestore {
 
     match /deals-token-swap/{deal} {
       allow read: if isPublicDeal() || userIsProposalLead() || userIsRepresentative();
-      allow update: if userIsProposalLead() || (userIsRepresentative() && updateOnlyToDiscussions());
+      allow update: if userIsProposalLead() || (userIsAuthenticated() && updateOnlyToDiscussions());
       allow create, delete: if false;
     }
-    
+
     match /deals-token-swap/{deal}/primary-dao-votes/{representative} {
-    	allow read, create, delete: if false;
-    	allow update: if request.auth.uid == resource.id;
+      allow read, create, delete: if false;
+      allow update: if request.auth.uid == resource.id;
     }
 
     match /deals-token-swap/{deal}/partner-dao-votes/{representative} {
-    	allow read, create, delete: if false;
-    	allow update: if request.auth.uid == resource.id;
+      allow read, create, delete: if false;
+      allow update: if request.auth.uid == resource.id;
     }
-    
+
     match /{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## What was done
- update firestore rule `userIsRepresentative -> userIsAuthenticated`
- added 3 test cases for 
  - Lead
  - Rep
  - Connected Public User



## Testing
(or observe `discussions-create.feature` :d)

1. New open prop with no discussions started (best to create new one)
2. one address and role from the 3 cases

#### Before
3. Bug: auth error for "Connected Public"

#### After
3. Fix: okay for "Connected Public"

## Fix verification
Rerun e2e tests with "old" firestore rules --> broke as expected