### PR TITLE
593 - Catch thread comments undefined

### DIFF
--- a/cypress/integration/features/dealDashboard/discussions/discussions-create.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-create.feature
@@ -3,7 +3,6 @@ Feature: Discussions create
     Given I'm a Connected Public user
     And I create an Open Proposal
 
-  @focus
   Scenario: Creating a Discussion - No Discussions for Clause yet
     When I'm viewing the Open Proposal
     Then I should be informed of no discussions
@@ -11,3 +10,9 @@ Feature: Discussions create
 
   Scenario: Creating a Discussion - Info text
     # This discussion has no comments yet
+
+  Scenario: Creating a Discussion - 3rd party error
+    Given I'm viewing the Open Proposal
+    When the 3rd party Discussions service has an error
+    And I can create a new Discussion
+    Then I should be informed about the error and can retry

--- a/cypress/integration/features/dealDashboard/discussions/discussions-create.feature
+++ b/cypress/integration/features/dealDashboard/discussions/discussions-create.feature
@@ -3,13 +3,12 @@ Feature: Discussions create
     Given I'm a Connected Public user
     And I create an Open Proposal
 
-  @focus
   Scenario Outline: Creating a Discussion - No Discussions for Clause yet
     Given I'm a "<UserType>" user
     And I'm viewing a new public Open Proposal
     Then I should be informed of no discussions
     And I can create a new Discussion
-    And I'm informed about, that the discussion has no comments yet
+    And I should be informed, that the discussion has no comments yet
 
     Examples:
       | UserType         |
@@ -25,6 +24,8 @@ Feature: Discussions create
 
   Scenario: Creating a Discussion - 3rd party error
     Given I'm viewing the Open Proposal
-    When the 3rd party Discussions service has an error
-    And I can create a new Discussion
-    Then I should be informed about the error and can retry
+    And the 3rd party Discussions service has an error
+    When I can create a new Discussion
+    Then I should be informed about the error
+    When I reload the discussions
+    Then I should be informed, that the discussion has no comments yet

--- a/cypress/integration/tests/dealDashboard/discussion.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/discussion.e2e.ts
@@ -4,6 +4,8 @@ import { PAGE_LOADING_TIMEOUT } from "../../common/test-constants";
 import { E2eDeals } from "../deals/deals.e2e";
 import { E2eWallet } from "../wallet.e2e";
 
+export const GET_COMMENTS_ALIAS = "getComments";
+
 interface ICommentOptions {
   notAuthor?: boolean;
   isAuthor?: boolean;
@@ -266,6 +268,23 @@ Then("I can create a new Discussion", () => {
 
 Then("I am presented with the latest comment", () => {
   E2eDiscussion.getSingleComment().should("have.value");
+});
+
+When("the 3rd party Discussions service has an error", () => {
+  cy.log("intercept convo");
+  const discussionsServiceUrl = "**/comments**";
+  cy.intercept(
+    "GET",
+    discussionsServiceUrl,
+    {
+      statusCode: 503,
+      body: null,
+    },
+  ).as(GET_COMMENTS_ALIAS);
+});
+
+Then("I should be informed about the error and can retry", () => {
+  cy.get("[data-test='discussions-api-error']").should("be.visible");
 });
 
 And("I cannot reply to a Comment", () => {

--- a/cypress/integration/tests/dealDashboard/discussion.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/discussion.e2e.ts
@@ -272,19 +272,15 @@ Then("I am presented with the latest comment", () => {
 
 When("the 3rd party Discussions service has an error", () => {
   cy.log("intercept convo");
-  const discussionsServiceUrl = "**/comments**";
-  cy.intercept(
-    "GET",
-    discussionsServiceUrl,
-    {
-      statusCode: 503,
-      body: null,
-    },
-  ).as(GET_COMMENTS_ALIAS);
+  const errorResponse = { statusCode: 503, body: null };
+  const routeOptions = { method: "GET", times: 1 };
+
+  cy.intercept("**/comments**", routeOptions, errorResponse).as(GET_COMMENTS_ALIAS);
+  cy.intercept("**/getAblyAuth**", routeOptions, errorResponse);
 });
 
 Then("I should be informed about the error and can retry", () => {
-  cy.get("[data-test='discussions-api-error']").should("be.visible");
+  cy.get("[data-test='reload-discussions']").should("be.visible");
 });
 
 And("I cannot reply to a Comment", () => {

--- a/cypress/integration/tests/dealDashboard/discussion.e2e.ts
+++ b/cypress/integration/tests/dealDashboard/discussion.e2e.ts
@@ -19,7 +19,7 @@ export class E2eDiscussion {
   }
 
   public static getAddOrReadButton() {
-    return cy.get("[data-test='add-or-read-button']");
+    return cy.get("[data-test='add-or-read-button']", {timeout: PAGE_LOADING_TIMEOUT});
   }
 
   public static getDiscussionsList() {
@@ -196,6 +196,19 @@ When("I view my own Comment", () => {
   E2eDiscussion.hoverSingleComment({isAuthor: true});
 });
 
+When("the 3rd party Discussions service has an error", () => {
+  cy.log("intercept convo");
+  const errorResponse = { statusCode: 503, body: null };
+  const routeOptions = { method: "GET", times: 1 };
+
+  cy.intercept("**/comments**", routeOptions, errorResponse).as(GET_COMMENTS_ALIAS);
+  cy.intercept("**/getAblyAuth**", routeOptions, errorResponse);
+});
+
+When("I reload the discussions", () => {
+  cy.get("[data-test='reload-discussions']").click();
+});
+
 Then("I should not be able to see Discussions", () => {
   E2eDiscussion.getDealClauses().should("not.exist");
 });
@@ -270,24 +283,15 @@ Then("I am presented with the latest comment", () => {
   E2eDiscussion.getSingleComment().should("have.value");
 });
 
-When("the 3rd party Discussions service has an error", () => {
-  cy.log("intercept convo");
-  const errorResponse = { statusCode: 503, body: null };
-  const routeOptions = { method: "GET", times: 1 };
-
-  cy.intercept("**/comments**", routeOptions, errorResponse).as(GET_COMMENTS_ALIAS);
-  cy.intercept("**/getAblyAuth**", routeOptions, errorResponse);
+Then("I should be informed about the error", () => {
+  cy.get("[data-test='reload-discussions']").should("be.visible");
 });
 
-Then("I should be informed about the error and can retry", () => {
-  cy.get("[data-test='reload-discussions']").should("be.visible");
+Then("I should be informed, that the discussion has no comments yet", () => {
+  E2eDiscussion.waitForNoCommentsText();
 });
 
 And("I cannot reply to a Comment", () => {
 
   cy.log("todo");
-});
-
-Then("I'm informed about, that the discussion has no comments yet", () => {
-  E2eDiscussion.waitForNoCommentsText();
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint.fix": "npm run lint -- --fix",
     "fetchContracts": "node scripts/fetchContracts.js",
     "firebase": "npm run firebase-functions:build && npm run firebase-emulators:start",
-    "firebase-e2e": "npm run firebase-functions:build && firebase emulators:start --project=default --import=firebase_seed_e2e",
+    "firebase-e2e": "firebase emulators:start --project=default --import=firebase_seed_e2e",
     "firebase:all": "npm run firebase-functions:watch & npm run firebase-emulators:start",
     "firebase-update-seed-data": "firebase emulators:export --force firebase_seed",
     "firebase-update-seed-data:e2e": "firebase emulators:export --project=default --force firebase_seed_e2e",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint.fix": "npm run lint -- --fix",
     "fetchContracts": "node scripts/fetchContracts.js",
     "firebase": "npm run firebase-functions:build && npm run firebase-emulators:start",
-    "firebase-e2e": "firebase emulators:start --project=default --import=firebase_seed_e2e",
+    "firebase-e2e": "npm run firebase-functions:build && firebase emulators:start --project=default --import=firebase_seed_e2e",
     "firebase:all": "npm run firebase-functions:watch & npm run firebase-emulators:start",
     "firebase-update-seed-data": "firebase emulators:export --force firebase_seed",
     "firebase-update-seed-data:e2e": "firebase emulators:export --project=default --force firebase_seed_e2e",

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -32,7 +32,7 @@
         <div if.bind="!isLoading.discussions && !threadComments.length" data-test="no-comments-text" class="no comment">
           <span if.bind="apiErrorText" class="fas fa-exclamation-triangle"></span>
           ${noCommentsText}
-          <span if.bind="apiErrorText">
+          <span if.bind="apiErrorText" data-test="discussions-api-error">
             5s
             <button
               data-test="add-dao-representative"

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -29,13 +29,7 @@
           <i class="spinner fa fas fa-circle-notch fa-spin"></i>
           Loading comments...
         </div>
-        <div
-          if.bind="!isLoading.discussions && !threadComments.length"
-          data-test="no-comments-text"
-          class="
-            no comment
-          "
-        >
+        <div if.bind="!isLoading.discussions && !threadComments.length" data-test="no-comments-text" class="no comment">
           <template if.bind="!hasApiError">
             ${noCommentsText}
           </template>

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -29,19 +29,24 @@
           <i class="spinner fa fas fa-circle-notch fa-spin"></i>
           Loading comments...
         </div>
-        <div if.bind="!isLoading.discussions && !threadComments.length" data-test="no-comments-text" class="no comment">
-          <span if.bind="apiErrorText" class="fas fa-exclamation-triangle"></span>
-          ${noCommentsText}
-          <span if.bind="apiErrorText" data-test="discussions-api-error">
-            5s
-            <button
-              data-test="add-dao-representative"
-              class="addButton"
-              style="color: #9398a8;"
-              click.delegate="addRepresentative()">
-              (Retry now)
-            </button>
-          </span>
+        <div
+          if.bind="!isLoading.discussions && !threadComments.length"
+          data-test="no-comments-text"
+          class="
+            no comment
+            ${apiErrorText ? 'discussions-loading-error' : ''}
+          "
+        >
+          <div>
+            <span if.bind="apiErrorText" class="fas fa-exclamation-triangle"></span>
+            ${noCommentsText}
+          </div>
+          <pbutton
+            if.bind="apiErrorText"
+            data-test="reload-discussions"
+            class="reload-discussions"
+            type="primary"
+          >Reload Discussion</pbutton>
         </div>
 
         <div

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -46,6 +46,7 @@
             data-test="reload-discussions"
             class="reload-discussions"
             type="primary"
+            click.delegate="initialize()"
           >Reload Discussion</pbutton>
         </div>
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -34,20 +34,23 @@
           data-test="no-comments-text"
           class="
             no comment
-            ${apiErrorText ? 'discussions-loading-error' : ''}
           "
         >
-          <div>
-            <span if.bind="apiErrorText" class="fas fa-exclamation-triangle"></span>
+          <template if.bind="!hasApiError">
             ${noCommentsText}
+          </template>
+          <div else class="discussions-loading-error">
+            <div>
+              <span class="fas fa-exclamation-triangle"></span>
+              A problem occured while loading the discussion
+            </div>
+            <pbutton
+              data-test="reload-discussions"
+              class="reload-discussions"
+              type="primary"
+              click.delegate="initialize()"
+            >Reload Discussion</pbutton>
           </div>
-          <pbutton
-            if.bind="apiErrorText"
-            data-test="reload-discussions"
-            class="reload-discussions"
-            type="primary"
-            click.delegate="initialize()"
-          >Reload Discussion</pbutton>
         </div>
 
         <div

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -30,7 +30,18 @@
           Loading comments...
         </div>
         <div if.bind="!isLoading.discussions && !threadComments.length" data-test="no-comments-text" class="no comment">
+          <span if.bind="apiErrorText" class="fas fa-exclamation-triangle"></span>
           ${noCommentsText}
+          <span if.bind="apiErrorText">
+            5s
+            <button
+              data-test="add-dao-representative"
+              class="addButton"
+              style="color: #9398a8;"
+              click.delegate="addRepresentative()">
+              (Retry now)
+            </button>
+          </span>
         </div>
 
         <div

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.scss
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.scss
@@ -61,7 +61,7 @@
           margin-right: 4px;
         }
 
-        &.discussions-loading-error {
+        .discussions-loading-error {
           @include subHeading;
           font-size: $font-size4;
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.scss
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.scss
@@ -55,6 +55,20 @@
           padding-top: $spacing-normal * 3;
           padding-bottom: $spacing-normal * 5;
         }
+
+        .fa-exclamation-triangle {
+          color: $Orange;
+          margin-right: 4px;
+        }
+
+        &.discussions-loading-error {
+          @include subHeading;
+          font-size: $font-size4;
+
+          .reload-discussions {
+            margin-top: 24px;
+          }
+        }
       }
     }
     .load-more {

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -53,7 +53,7 @@ export class DiscussionThread {
     downvotes: [""],
     createdOn: "0",
   };
-  private apiErrorText = "";
+  private hasApiError = false;
 
   constructor(
     private router: Router,
@@ -91,10 +91,6 @@ export class DiscussionThread {
 
   @computedFrom("isLoading.discussions", "deal.isUserRepresentativeOrLead", "threadComments", "apiErrorText")
   private get noCommentsText(): string {
-    if (this.apiErrorText) {
-      return this.apiErrorText;
-    }
-
     if (!this.isLoading.discussions && !this.threadComments?.length) {
       return (!this.deal.isUserRepresentativeOrLead && this.deal.isPrivate)
         ? "This discussion is private."
@@ -203,12 +199,12 @@ export class DiscussionThread {
     try {
       this.threadComments = await this.discussionsService.loadDiscussionComments(discussionId);
 
+      this.hasApiError = false;
+
       // Early return, if there are no comments/discussions.
       if (!this.threadComments) return;
-
-      this.apiErrorText = "";
     } catch (error) {
-      this.apiErrorText = "A problem occured while loading the discussion";
+      this.hasApiError = true;
 
       this.consoleLogService.logMessage(error.message, "error");
     }

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -16,6 +16,7 @@ import "./discussionThread.scss";
 // import { Convo } from "@theconvospace/sdk";
 import { Realtime } from "ably/promises";
 import { Types } from "ably";
+import { ConsoleLogService } from "services/ConsoleLogService";
 
 @autoinject
 export class DiscussionThread {
@@ -58,6 +59,7 @@ export class DiscussionThread {
     private router: Router,
     private dateService: DateService,
     private dealService: DealService,
+    private consoleLogService: ConsoleLogService,
     private discussionsService: DiscussionsService,
     private ethereumService: EthereumService,
     private eventAggregator: EventAggregator,
@@ -201,15 +203,16 @@ export class DiscussionThread {
   private async ensureDealDiscussion(discussionId: string): Promise<void> {
     try {
       this.threadComments = await this.discussionsService.loadDiscussionComments(discussionId);
-      /* prettier-ignore */ console.log("TCL ~ file: discussionThread.ts ~ line 198 ~ DiscussionThread ~ ensureDealDiscussion ~ this.threadComments", this.threadComments);
 
       // Early return, if there are no comments/discussions.
       if (!this.threadComments) return;
 
       this.apiErrorText = "";
     } catch (error) {
-      console.log("API error");
       this.apiErrorText = "There was an issue loading the comments. Retrying in: ";
+
+      this.consoleLogService.logMessage(error.message, "error");
+
       if (!this.threadComments) this.threadComments = [];
     }
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -88,12 +88,14 @@ export class DiscussionThread {
 
   @computedFrom("isLoading.discussions", "deal.isUserRepresentativeOrLead", "threadComments")
   private get noCommentsText(): string {
-    if (!this.isLoading.discussions && !this.threadComments?.length) {
-      return (!this.deal.isUserRepresentativeOrLead && this.deal.isPrivate)
-        ? "This discussion is private."
-        : "This discussion has no comments yet.";
+    /* prettier-ignore */ console.log("TCL ~ file: discussionThread.ts ~ line 91 ~ DiscussionThread ~ getnoCommentsText ~ noCommentsText");
+    if (this.isLoading.discussions || this.threadComments?.length) {
+      return "";
     }
-    return "";
+
+    return (!this.deal.isUserRepresentativeOrLead && this.deal.isPrivate)
+      ? "This discussion is private."
+      : "This discussion has no comments yet.";
   }
 
   private async initialize(isIdChange = false): Promise<void> {
@@ -195,11 +197,13 @@ export class DiscussionThread {
   private async ensureDealDiscussion(discussionId: string): Promise<void> {
     try {
       this.threadComments = await this.discussionsService.loadDiscussionComments(discussionId);
+      /* prettier-ignore */ console.log("TCL ~ file: discussionThread.ts ~ line 198 ~ DiscussionThread ~ ensureDealDiscussion ~ this.threadComments", this.threadComments);
 
       // Early return, if there are no comments/discussions.
-      if (!this.threadComments) return;
+      // if (!this.threadComments) return;
     } catch (error) {
       console.log("API error");
+      if (!this.threadComments) this.threadComments = [];
     }
 
     if (!this.dealDiscussion) return;
@@ -259,8 +263,7 @@ export class DiscussionThread {
     const efp = (x, y) => document.elementFromPoint(x, y);
 
     if (rect.height < 0 || rect.bottom < 0 ||
-        rect.left > vWidth || rect.top > vHeight)
-      return false;
+        rect.left > vWidth || rect.top > vHeight) return false;
 
     return (
       this.refThread.contains(efp(rect.left, rect.top)) ||

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -95,13 +95,12 @@ export class DiscussionThread {
       return this.apiErrorText;
     }
 
-    if (this.isLoading.discussions || this.threadComments?.length) {
-      return "";
+    if (!this.isLoading.discussions && !this.threadComments?.length) {
+      return (!this.deal.isUserRepresentativeOrLead && this.deal.isPrivate)
+        ? "This discussion is private."
+        : "This discussion has no comments yet.";
     }
-
-    return (!this.deal.isUserRepresentativeOrLead && this.deal.isPrivate)
-      ? "This discussion is private."
-      : "This discussion has no comments yet.";
+    return "";
   }
 
   private async initialize(isIdChange = false): Promise<void> {

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -209,7 +209,7 @@ export class DiscussionThread {
 
       this.apiErrorText = "";
     } catch (error) {
-      this.apiErrorText = "There was an issue loading the comments. Retrying in: ";
+      this.apiErrorText = "A problem occured while loading the discussion";
 
       this.consoleLogService.logMessage(error.message, "error");
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -211,8 +211,6 @@ export class DiscussionThread {
       this.apiErrorText = "A problem occured while loading the discussion";
 
       this.consoleLogService.logMessage(error.message, "error");
-
-      if (!this.threadComments) this.threadComments = [];
     }
 
     if (!this.dealDiscussion) return;
@@ -228,41 +226,38 @@ export class DiscussionThread {
         this.isLoading[this.dealDiscussion.createdBy.address] = false;
       });
 
-    // eslint-disable-next-line no-constant-condition
-    if (true) {
-      this.subscribeToDiscussion(discussionId);
+    this.subscribeToDiscussion(discussionId);
 
-      if (!this.threadComments || !Object.keys(this.threadComments).length) return;
+    if (!this.threadComments || !Object.keys(this.threadComments).length) return;
 
-      // Dictionary is used for replies, to easily find the comment by its id
-      this.threadDictionary = this.arrayToDictionary(this.threadComments);
+    // Dictionary is used for replies, to easily find the comment by its id
+    this.threadDictionary = this.arrayToDictionary(this.threadComments);
 
-      /* Comments author profiles */
-      this.threadComments.forEach((comment: IComment) => {
-        if (!this.threadProfiles[comment.author]) {
-          this.isLoading[comment.author] = true;
-          if (comment.authorENS /* author has ENS name */) {
-            this.threadProfiles[comment.author] = {
-              name: comment.authorENS,
-              address: comment.author,
-              image: "",
-            };
-          } else {
-            /* required for replies */
-            this.discussionsService.loadProfile(comment.author).then(profile => {
-              this.threadProfiles[comment.author] = profile;
-              this.isLoading[comment.author] = false;
-            });
-          }
+    /* Comments author profiles */
+    this.threadComments.forEach((comment: IComment) => {
+      if (!this.threadProfiles[comment.author]) {
+        this.isLoading[comment.author] = true;
+        if (comment.authorENS /* author has ENS name */) {
+          this.threadProfiles[comment.author] = {
+            name: comment.authorENS,
+            address: comment.author,
+            image: "",
+          };
+        } else {
+          /* required for replies */
+          this.discussionsService.loadProfile(comment.author).then(profile => {
+            this.threadProfiles[comment.author] = profile;
+            this.isLoading[comment.author] = false;
+          });
         }
-      });
+      }
+    });
 
-      // Update the discussion status
-      this.updateDiscussionListStatus(
-        new Date(parseFloat(this.threadComments[this.threadComments.length - 1].createdOn)),
-        this.threadComments.length,
-      );
-    }
+    // Update the discussion status
+    this.updateDiscussionListStatus(
+      new Date(parseFloat(this.threadComments[this.threadComments.length - 1].createdOn)),
+      this.threadComments.length,
+    );
   }
 
   private isInView(element: HTMLElement): boolean {

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -52,6 +52,7 @@ export class DiscussionThread {
     downvotes: [""],
     createdOn: "0",
   };
+  private apiErrorText = "";
 
   constructor(
     private router: Router,
@@ -86,9 +87,12 @@ export class DiscussionThread {
     return (discussionsIds.indexOf(this.discussionId) + 1).toString() || "-";
   }
 
-  @computedFrom("isLoading.discussions", "deal.isUserRepresentativeOrLead", "threadComments")
+  @computedFrom("isLoading.discussions", "deal.isUserRepresentativeOrLead", "threadComments", "apiErrorText")
   private get noCommentsText(): string {
-    /* prettier-ignore */ console.log("TCL ~ file: discussionThread.ts ~ line 91 ~ DiscussionThread ~ getnoCommentsText ~ noCommentsText");
+    if (this.apiErrorText) {
+      return this.apiErrorText;
+    }
+
     if (this.isLoading.discussions || this.threadComments?.length) {
       return "";
     }
@@ -200,9 +204,12 @@ export class DiscussionThread {
       /* prettier-ignore */ console.log("TCL ~ file: discussionThread.ts ~ line 198 ~ DiscussionThread ~ ensureDealDiscussion ~ this.threadComments", this.threadComments);
 
       // Early return, if there are no comments/discussions.
-      // if (!this.threadComments) return;
+      if (!this.threadComments) return;
+
+      this.apiErrorText = "";
     } catch (error) {
       console.log("API error");
+      this.apiErrorText = "There was an issue loading the comments. Retrying in: ";
       if (!this.threadComments) this.threadComments = [];
     }
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -89,7 +89,7 @@ export class DiscussionThread {
     return (discussionsIds.indexOf(this.discussionId) + 1).toString() || "-";
   }
 
-  @computedFrom("isLoading.discussions", "deal.isUserRepresentativeOrLead", "threadComments", "apiErrorText")
+  @computedFrom("isLoading.discussions", "deal.isUserRepresentativeOrLead", "threadComments")
   private get noCommentsText(): string {
     if (!this.isLoading.discussions && !this.threadComments?.length) {
       return (!this.deal.isUserRepresentativeOrLead && this.deal.isPrivate)

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -193,7 +193,17 @@ export class DiscussionThread {
   }
 
   private async ensureDealDiscussion(discussionId: string): Promise<void> {
-    this.threadComments = await this.discussionsService.loadDiscussionComments(discussionId);
+    try {
+      this.threadComments = await this.discussionsService.loadDiscussionComments(discussionId);
+
+      // Early return, if there are no comments/discussions.
+      if (!this.threadComments) return;
+    } catch (error) {
+      console.log("API error");
+    }
+
+    if (!this.dealDiscussion) return;
+
     this.updateDiscussionListStatus(new Date(), this.threadComments.length);
     this.isLoading.discussions = false;
 
@@ -205,7 +215,8 @@ export class DiscussionThread {
         this.isLoading[this.dealDiscussion.createdBy.address] = false;
       });
 
-    if (this.threadComments && this.dealDiscussion) {
+    // eslint-disable-next-line no-constant-condition
+    if (true) {
       this.subscribeToDiscussion(discussionId);
 
       if (!this.threadComments || !Object.keys(this.threadComments).length) return;

--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -298,6 +298,7 @@ export class DiscussionsService {
       return [...await commentsThread];
     } catch (error) {
       this.consoleLogService.logMessage("loadDiscussionComments: " + error.message);
+      throw error;
     }
   }
 

--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -297,7 +297,7 @@ export class DiscussionsService {
 
       return [...await commentsThread];
     } catch (error) {
-      this.consoleLogService.logMessage("loadDiscussionComments: " + error.message);
+      this.consoleLogService.logMessage("loadDiscussionComments: " + error.message, "error");
       throw error;
     }
   }


### PR DESCRIPTION
Related
599
601
603

## What was done
- throw error for network call in `DiscussionService`
  - Why? So caller can catch and handle api related errors (eg. show retry)
- Early return `ensureDealDiscussion`

## Testing
Right now, unstable, because convo sometimes okay, sometimes not

#### Before
always infinite loading

#### After
handle, and display default "This discussion has no comments yet."