### PR TITLE
Handle wallet change, while deals are initialising for another wallet

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import { DealService } from "services/DealService";
 import "./styles/styles.scss";
 import "./app.scss";
 
@@ -11,7 +12,6 @@ import { ConsoleLogService } from "services/ConsoleLogService";
 import { EthereumService } from "services/EthereumService";
 import { EventAggregator } from "aurelia-event-aggregator";
 import { EventConfigException } from "services/GeneralEvents";
-import { FirebaseService } from "./services/FirebaseService";
 import { PLATFORM } from "aurelia-pal";
 import { ShowButtonsEnum } from "resources/elements/primeDesignSystem/ppopup-modal/ppopup-modal";
 /* eslint-disable linebreak-style */
@@ -29,7 +29,7 @@ export class App {
     private consoleLogService: ConsoleLogService,
     private alertService: AlertService,
     private storageService: BrowserStorageService,
-    private firebaseService: FirebaseService) { }
+    private dealService: DealService) { }
 
   router: Router;
   onOff = false;
@@ -45,7 +45,7 @@ export class App {
     return false;
   };
 
-  public attached(): void {
+  public async attached(): Promise<void> {
     // so all elements with data-tippy-content will automatically have a tooltip
     tippy("[data-tippy-content]");
 
@@ -120,7 +120,12 @@ export class App {
      */
     document.querySelector("body").classList.remove("loading");
 
-    this.ethereumService.connectToConnectedProvider();
+    await this.ethereumService.connectToConnectedProvider();
+
+    /**
+     * do this after we've gotten an account, if there is one
+     */
+    this.dealService.initialize();
   }
 
   private handleOnOff(onOff: boolean): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,6 @@ import { EventConfigException } from "services/GeneralEvents";
 import { ConsoleLogService } from "services/ConsoleLogService";
 import { ContractsService } from "services/ContractsService";
 import { EventAggregator } from "aurelia-event-aggregator";
-import { DealService } from "services/DealService";
 import { IpfsService } from "services/IpfsService";
 import { HTMLSanitizer } from "aurelia-templating-resources";
 import DOMPurify from "dompurify";
@@ -93,10 +92,6 @@ export function configure(aurelia: Aurelia): void {
       const tokenService = aurelia.container.get(TokenService);
       await tokenService.initialize();
       TimingService.end("TokenService Initialization");
-
-      const dealService = aurelia.container.get(DealService);
-      dealService.initialize();
-
     } catch (ex) {
       const eventAggregator = aurelia.container.get(EventAggregator);
       eventAggregator.publish("handleException", new EventConfigException("Sorry, couldn't connect to ethereum", ex));

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ export function configure(aurelia: Aurelia): void {
 
       /**
        * must do before ethereum service, to capture network connections
+       * and in general to be the first to do so.
        */
       const firebaseService = aurelia.container.get(FirebaseService);
       firebaseService.initialize();

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -99,9 +99,10 @@ export class DealService {
   }
 
   /**
-   * Best to invoke this after a wallet has been connected and before anyone else subscribes to
-   * Network.Changed.Account.  We want to be the first, so others can ideally have up-to-date
-   * deals when they handle a new account.
+   * Best to invoke this after the very first wallet has been connected as the app is loading
+   * and before anyone else subscribes to Network.Changed.Account.
+   * We want to be the first, so others can ideally have up-to-date deals
+   * when they handle a new account.
    */
   public async initialize(): Promise<void> {
     this.eventAggregator.subscribe("Network.Changed.Account", async (): Promise<void> => {

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -100,6 +100,8 @@ export class DealService {
         try {
           this.eventAggregator.publish("deals.loading", true);
           await this.getDeals(true);
+        } catch {
+          this.eventAggregator.publish("deals.loading", false);
         } finally {
           this.eventAggregator.publish("deals.loading", false);
         }
@@ -149,6 +151,9 @@ export class DealService {
                 this.initializing = false;
               }
             }
+          }).catch(() => {
+            this.initializing = false;
+            reject();
           });
         });
       });

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -112,11 +112,11 @@ export class DealService {
 
     this.initializing = true;
 
-    return this.initializedPromise = new Promise(
+    return this.initializedPromise = new Promise<void>(
       (resolve: (value: void | PromiseLike<void>) => void,
-        reject: (reason?: any) => void): void => {
-        this.getDealInfo().then(() => {
-          this.dataSourceDeals.getDeals<IDealTokenSwapDocument>(this.ethereumService.defaultAccountAddress).then((dealDocs) => {
+        reject: (reason?: any) => void): Promise<void> => {
+        return this.getDealInfo().then(() => {
+          return this.dataSourceDeals.getDeals<IDealTokenSwapDocument>(this.ethereumService.defaultAccountAddress).then((dealDocs) => {
             if (force || !this.deals?.size) {
               if (!dealDocs) {
                 throw new Error("Deals are not accessible");
@@ -129,7 +129,7 @@ export class DealService {
                 this._createDeal(dealDoc, dealsMap);
               }
               this.deals = dealsMap;
-              resolve();
+              return resolve();
             }
           });
         })

--- a/src/services/EthereumService.ts
+++ b/src/services/EthereumService.ts
@@ -272,7 +272,7 @@ export class EthereumService {
           const account = getAddress(accounts[0]);
           if (this.disclaimerService.getPrimeDisclaimed(account)) {
             this.consoleLogService.logMessage(`autoconnecting to ${account}`, "info");
-            this.setProvider(provider);
+            return this.setProvider(provider);
           }
         }
       }

--- a/src/services/EthereumService.ts
+++ b/src/services/EthereumService.ts
@@ -374,10 +374,10 @@ export class EthereumService {
   //   }
   // }
 
-  private handleAccountsChanged = async (accounts: Array<Address>) => {
+  private handleAccountsChanged = async (accounts?: Array<Address>) => {
     this.defaultAccount = await this.getCurrentAccountFromProvider(this.walletProvider);
     this.defaultAccountAddress = await this.getDefaultAccountAddress();
-    this.fireAccountsChangedHandler(accounts?.[0]);
+    this.fireAccountsChangedHandler(getAddress(accounts?.[0]));
   };
 
   private handleChainChanged = async (chainId: number) => {

--- a/src/services/FirestoreDealsService.ts
+++ b/src/services/FirestoreDealsService.ts
@@ -35,7 +35,7 @@ export class FirestoreDealsService<
       try {
         deals = await this.firestoreService.getAllDealsForTheUser(accountAddress);
       } catch (error) {
-        throw new Error(`Error while getting deals ${error}`);
+        throw new Error("Trying to load deals for a user that is not connected");
       }
     } else {
       this.consoleLogService.logMessage("getting all public deals");

--- a/src/services/FirestoreDealsService.ts
+++ b/src/services/FirestoreDealsService.ts
@@ -32,7 +32,11 @@ export class FirestoreDealsService<
         return;
       }
       this.consoleLogService.logMessage(`getting all deals for user ${accountAddress}`);
-      deals = await this.firestoreService.getAllDealsForTheUser(accountAddress);
+      try {
+        deals = await this.firestoreService.getAllDealsForTheUser(accountAddress);
+      } catch (error) {
+        throw new Error(`Error while getting deals ${error}`);
+      }
     } else {
       this.consoleLogService.logMessage("getting all public deals");
       deals = await this.firestoreService.getAllPublicDeals();

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -164,8 +164,8 @@ export class FirestoreService<
    *
    * @returns Promise<IFirebaseDocument<TDealDocument>[]>
    */
-  public async getAllPublicDeals<TDealDocument>(): Promise<Array<IFirebaseDocument<TDealDocument>>> {
-    return await this.getDealDocuments(this.allPublicDealsQuery());
+  public getAllPublicDeals<TDealDocument>(): Promise<Array<IFirebaseDocument<TDealDocument>>> {
+    return this.getDealDocuments(this.allPublicDealsQuery());
   }
 
   /**
@@ -176,8 +176,8 @@ export class FirestoreService<
    * @param address string
    * @returns Promise<IFirebaseDocument<TDealDocument>[]>
    */
-  public async getRepresentativeDeals(address: Address): Promise<Array<IFirebaseDocument<TDealDocument>>> {
-    return await this.getDealDocuments(this.representativeDealsQuery(address));
+  public getRepresentativeDeals(address: Address): Promise<Array<IFirebaseDocument<TDealDocument>>> {
+    return this.getDealDocuments(this.representativeDealsQuery(address));
   }
 
   /**
@@ -188,8 +188,8 @@ export class FirestoreService<
    * @param address string
    * @returns Promise<IFirebaseDocument<TDealDocument>[]>
    */
-  public async getProposalLeadDeals(address: Address): Promise<Array<IFirebaseDocument<TDealDocument>>> {
-    return await this.getDealDocuments(this.proposalLeadDealsQuery(address));
+  public getProposalLeadDeals(address: Address): Promise<Array<IFirebaseDocument<TDealDocument>>> {
+    return this.getDealDocuments(this.proposalLeadDealsQuery(address));
   }
 
   /**


### PR DESCRIPTION
# Error when changing account in MetaMask:
**Background:**
Representative addresses and proposal lead address are stored as is, they are NOT transformed to lowerCase.
All queries also don’t transform addresses to lowerCase, e.g. where("registrationData.proposalLead.address", "==", address) 
When user is authenticated to Firebase, we also don’t transform the address to lowerCase.

**Issue:**
Somehow, when using MM and Chrome, this event in FirebaseService, emits address transformed to lowerCase, when changing account in MM

  public initialize(): void {
    this.eventAggregator.subscribe("Network.Changed.Account", (address: Address) => {
      this.syncFirebaseAuthentication(address);
    });
  }

When refreshing the page, first time it emits address that is NOT lowerCase.
But everytime the address is changed in MM it emits lowercase address.

Therefore, the user was authenticated to Firebase with lowercase address, and that why there was permissions issue, because firestore rules, as well as queries where looking for NOT lowerCase address but they were getting a lowerCase one.

**Solution:**
Always convert addresses to lowerCase

## TODO
Update all data in all firebase project, to have all addresses stored in lowerCase.
That includes updating vote documents in primary-dao-votes and partner-dao-votes subcollections, to have document id (equals to wallet address) in lowerCase

# Issue when changing wallet twice quickly (while deals are still initialising for the previous address)

## What was done
Changing wallet while deals are being initialized for another wallet, causes getting deals from dataSourceDeals to fail. When it fails in my opinion we should reset deals Map in DealService.

GetDeals method in DealService should we triggered every time an address is changes, so for example:
1. I'm connected to wallet A and I can see deals for wallet A
2. I switch to wallet B, getDeals method is triggered, but before it can finish I switch back to wallet A
3. Getting deals for wallet B fails, because wallet B is no longer authenticated with firebase
4. getDeals method that was triggered for wallet B, resets deals Map (because it failed to get deals, it shouldn't show the old ones)
5. (not implemented) After switching back to wallet A, getDeals method should be triggered again, then when it succeeds, deals Map should be set to the deals for wallet A, coming from getDeals method. It doesn't work because currently on account address change, we change if initializing is in progress.
```
this.eventAggregator.subscribe("Network.Changed.Account", async (): Promise<void> => {
    // because of this condition, getDeals is not triggered when other getDeals is still in progress (initializing),
    // therefore we cannot correctly react to account changes
      if (!this.initializing) { 
        try {
          this.eventAggregator.publish("deals.loading", true);
          await this.getDeals(true);
        } catch {
          this.eventAggregator.publish("deals.loading", false);
        } finally {
          this.eventAggregator.publish("deals.loading", false);
        }
      }
    });
```

## Testing
Start app with wallet account A. Open wallet and change the account to B and rapidly back to A, (you might have up to a few seconds for this). It might be difficult to reproduce this when using firebase emulators, when debugging locally, connect to live firebase project.

#### Before
App was broken when wallet change occurred while deals where being initialised for another wallet.
In other words the app was try to load private deals for a user, and the user got changed. So the first user was no longer authenticated to firebase, yet the app was still trying to get the deals for them, chance the error "Missing or insufficient permissions." That error wasn't handled.

#### After
Handle error while loading deals for a user, reset deals Map