### PR TITLE
Chore/581

### DIFF
--- a/src/dealDashboard/deal-swap-modal/deal-swap-modal.html
+++ b/src/dealDashboard/deal-swap-modal/deal-swap-modal.html
@@ -1,0 +1,32 @@
+<template>
+  <p>
+    You are about to execute token swapping between the following two DAOs. Do you want to execute
+    these swaps?
+  </p>
+  <div class="modal-content">
+    <div>
+      <h6>${deal.primaryDao.name} treasury address</h6>
+      <div class="dao">
+        <address-link
+          address="${deal.primaryDao.treasury_address}"
+          link-text="${deal.primaryDao.treasury_address}"
+          show-arrow-inside-link.bind="true"
+          show-tooltip.bind="false"
+        >
+        </address-link>
+      </div>
+    </div>
+    <div>
+      <h6>${deal.partnerDao.name} treasury address</h6>
+      <div class="dao">
+        <address-link
+          address="${deal.partnerDao.treasury_address}"
+          link-text="${deal.partnerDao.treasury_address}"
+          show-arrow-inside-link.bind="true"
+          show-tooltip.bind="false"
+        >
+        </address-link>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/dealDashboard/deal-swap-modal/deal-swap-modal.scss
+++ b/src/dealDashboard/deal-swap-modal/deal-swap-modal.scss
@@ -1,0 +1,50 @@
+@import "styles/styles.scss";
+@import "src/resources/elements/primeDesignSystem/styles";
+@import "src/resources/elements/primeDesignSystem/variables";
+@import "src/resources/elements/primeDesignSystem/colors";
+.ppopup-dialog.executeSwap {
+  p.dialogBody {
+    width: 550px;
+  }
+  .modal-content {
+    border-radius: 10px;
+    background-color: $BG02;
+    width: 100%;
+    padding: 20px;
+    margin-top: 40px;
+    display: grid;
+    grid-gap: 20px;
+    h6 {
+      text-transform: uppercase;
+      color: $Secondary02;
+      font-size: 14px;
+      font-weight: 700;
+      font-family: Aeonik;
+    }
+    .dao {
+      font-size: 14px;
+      color: #ffffff;
+      font-weight: 400;
+      font-family: Aeonik;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-column-gap: 10px;
+      .buttons {
+        display: flex;
+        column-gap: 4px;
+        align-items: center;
+
+        .etherscan-button {
+          outline: none;
+          path {
+            fill: $Secondary05;
+          }
+          cursor: pointer;
+          &:hover > path {
+            fill: $White;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/dealDashboard/deal-swap-modal/deal-swap-modal.ts
+++ b/src/dealDashboard/deal-swap-modal/deal-swap-modal.ts
@@ -1,0 +1,7 @@
+import { DealTokenSwap } from "entities/DealTokenSwap";
+import { bindable} from "aurelia-framework";
+import "./deal-swap-modal.scss";
+export class DealSwapModal {
+  @bindable deal: DealTokenSwap;
+
+}

--- a/src/dealDashboard/deal-swap-status/deal-swap-status.html
+++ b/src/dealDashboard/deal-swap-status/deal-swap-status.html
@@ -1,0 +1,46 @@
+<template>
+  <require from="../../funding/swap-status/swap-status"></require>
+  <require from="../../deals/timeLeft/timeLeft"></require>
+  <require from="../status-action-bar/status-action-bar"></require>
+  <swap-status deal.bind="deal" if.to-view="deal.primaryDao.tokens && deal.partnerDao">
+    <!-- Show this only when the deal is fully funded but before the swap has been executed -->
+    <status-action-bar
+      if.to-view="deal.isTargetReached && deal.isFunding"
+      content="IMPORTANT: Funding is complete so you must initiate swapping before the funding period expires in ${deal.timeLeftToExecute | timespan:'largest2'}."
+    >
+      <pbutton type="primary" click.delegate="executeSwap()" disabled.bind="isExecutingSwap">
+        Execute Swap <i class="fas">&#xf021;</i>
+      </pbutton>
+    </status-action-bar>
+    <!-- Show this only when the swap has been executed and the user is either the proposal lead or a representative -->
+    <status-action-bar
+      if.to-view="deal.isClaiming && !deal.isFullyClaimed && deal.isUserRepresentativeOrLead"
+      content="${deal.isRepresentativeUser ? 'Token swap has been executed and vesting is in progress.  Go To Deal Status to see the final state of the deal.' : null}"
+    >
+      <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
+        ${deal.isRepresentativeUser ? 'Go to Claim' : 'Go to Status'}
+        <i class="fas fa-arrow-right"></i>
+      </pbutton>
+    </status-action-bar>
+    <status-action-bar
+      if.to-view="deal.isClaiming && deal.isFullyClaimed && deal.isUserRepresentativeOrLead"
+      content="All the swaps have been completed.  Go To Deal Status to see the final state of the deal"
+      icon-class="check-circle"
+      icon-color="success"
+    >
+      <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
+        Go To Deal Status
+        <i class="fas fa-arrow-right"></i>
+      </pbutton>
+    </status-action-bar>
+    <status-action-bar
+      if.to-view="deal.isFailed && deal.isUserRepresentativeOrLead"
+      content="${deal.isRepresentativeUser ? 'IMPORTANT: You can withdraw your tokens at any time as this deal has failed.  Go To Withdraw to withdraw token deposits.' : null}"
+    >
+      <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
+        ${deal.isRepresentativeUser ? 'Go To Withdraw' : 'Go to Status'}
+        <i class="fas fa-arrow-right"></i>
+      </pbutton>
+    </status-action-bar>
+  </swap-status>
+</template>

--- a/src/dealDashboard/deal-swap-status/deal-swap-status.ts
+++ b/src/dealDashboard/deal-swap-status/deal-swap-status.ts
@@ -1,0 +1,64 @@
+import { DealTokenSwap } from "entities/DealTokenSwap";
+import "./deal-swap-status.scss";
+import { bindable, autoinject} from "aurelia-framework";
+import { AlertService, IAlertModel, ShowButtonsEnum } from "services/AlertService";
+import { Utils } from "services/utils";
+import { EventConfig, EventMessageType } from "services/GeneralEvents";
+import { EventAggregator } from "aurelia-event-aggregator";
+
+@autoinject
+export class DealSwapStatus {
+  @bindable deal: DealTokenSwap;
+  private isExecutingSwap = false;
+  constructor(
+    private eventAggregator: EventAggregator,
+    private alertService: AlertService,
+  ) {
+  }
+  public async activate() {
+    //wait until the dao transactions from the contract are there
+    await Utils.waitUntilTrue(() => this.deal.daoTokenTransactions !== undefined);
+    //wait until the dao token claims from the contract are there
+    await Utils.waitUntilTrue(() => this.deal.daoTokenClaims !== undefined);
+  }
+  /**
+   * Executes the token swap. Called by the "Execute Token Swap" button on the UI
+   *  - pops up a modal to verify the user wants to execute the swap
+   *  - does nothing if they hit cancel
+   *  - if they hit "execute" it will execute and show the congrats modal
+   */
+  public async executeSwap(): Promise<void> {
+    const swapModal: IAlertModel = {
+      header: "Execute token swap",
+      message: "<deal-swap-modal deal.bind='data.deal'></deal-swap-modal>", //TODO import modal HTML from deal-swap-modal.html
+      buttonTextPrimary: "Execute Swap <i style='margin-left:5px;' class='fa'>&#xf021;</i>",
+      buttonTextSecondary: "Cancel",
+      buttons: ShowButtonsEnum.Both,
+      data: {deal: this.deal},
+      className: "executeSwap",
+    };
+
+    // show a modal confirming the user wants to execute the swap
+    //const dialogResult = await this.alertService.showAlert(swapModal);
+    const dialogResult = await this.alertService.showAlert(swapModal);
+    if (!dialogResult.wasCancelled) {
+      this.isExecutingSwap = true;
+      //the user said they wanted to execute the swap so call the swap contract
+      const transactionReceipt = await this.deal.execute();
+      if (transactionReceipt){
+        //if the swap succeeded, show the 'congrats' modal
+        const congratulatePopupModel: IAlertModel = {
+          header: "Congratulations!",
+          message: "<p class='excitement'>You have successfully executed the token swap!</p>",
+          confetti: true,
+          buttonTextPrimary: "Close",
+          className: "congratulatePopup",
+        };
+        await this.alertService.showAlert(congratulatePopupModel);
+      } else {
+        this.eventAggregator.publish("handleError", new EventConfig("There was an error while attempting to execute the token swap. Please try again later", EventMessageType.Info, "Execute Swap Error"));
+      }
+      this.isExecutingSwap = false;
+    }
+  }
+}

--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -1,5 +1,4 @@
 <template>
-  <require from="../funding/swap-status/swap-status"></require>
   <require from="./dealMenubar/dealMenubar"></require>
   <require from="./dealVotes/dealVotes"></require>
   <require from="./dealInfo/dealInfo"></require>
@@ -7,7 +6,7 @@
   <require from="./dealDiscussion/dealDiscussion"></require>
   <require from="./dealMakeAnOffer/dealMakeAnOffer"></require>
   <require from="./dealDescription/dealDescription"></require>
-  <require from="./status-action-bar/status-action-bar"></require>
+  <require from="./deal-swap-status/deal-swap-status"></require>
   <require from="../deals/timeLeft/timeLeft"></require>
 
   <main
@@ -47,47 +46,7 @@
       discussion-id.two-way="discussionId"
       if.to-view="deal.isUserRepresentativeOrLead || !deal.isPrivate"
     ></deal-clauses>
-    <swap-status deal.bind="deal" if.to-view="deal.primaryDao.tokens && deal.partnerDao">
-      <!-- Show this only when the deal is fully funded but before the swap has been executed -->
-      <status-action-bar
-        if.to-view="deal.isTargetReached && deal.isFunding"
-        content="IMPORTANT: Funding is complete so you must initiate swapping before the funding period expires in XXXX days."
-      >
-        <pbutton type="primary" click.delegate="executeSwap()" disabled.bind="isExecutingSwap">
-          Execute Swap <i class="fas">&#xf021;</i>
-        </pbutton>
-      </status-action-bar>
-      <!-- Show this only when the swap has been executed and the user is either the proposal lead or a representative -->
-      <status-action-bar
-        if.to-view="deal.isClaiming && !deal.isFullyClaimed && deal.isUserRepresentativeOrLead"
-        content="${deal.isRepresentativeUser ? 'IMPORTANT: Go to Claiming to claim vested tokens for your DAO.' : null}"
-      >
-        <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
-          ${deal.isRepresentativeUser ? 'Go to Claiming' : 'Go to Status'}
-          <i class="fas fa-arrow-right"></i>
-        </pbutton>
-      </status-action-bar>
-      <status-action-bar
-        if.to-view="deal.isClaiming && deal.isFullyClaimed && deal.isUserRepresentativeOrLead"
-        content="All the swaps have been completed.  Go To Deal Status to see the final state of the deal."
-        icon-class="check-circle"
-        icon-color="success"
-      >
-        <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
-          Go To Deal Status
-          <i class="fas fa-arrow-right"></i>
-        </pbutton>
-      </status-action-bar>
-      <status-action-bar
-        if.to-view="deal.isFailed && deal.isUserRepresentativeOrLead"
-        content="${deal.isRepresentativeUser ? 'IMPORTANT: You can withdraw your tokens at any time as this deal has failed.  Go To Withdraw to withdraw token deposits.' : null}"
-      >
-        <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
-          ${deal.isRepresentativeUser ? 'Go To Withdraw' : 'Go to Status'}
-          <i class="fas fa-arrow-right"></i>
-        </pbutton>
-      </status-action-bar>
-    </swap-status>
+    <deal-swap-status deal.bind="deal"></deal-swap-status>
     <!-- Discussions / Discussion Comments Thread -->
     <deal-discussion
       authorized.bind="isAllowedToDiscuss"

--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -78,6 +78,15 @@
           <i class="fas fa-arrow-right"></i>
         </pbutton>
       </status-action-bar>
+      <status-action-bar
+        if.to-view="deal.isFailed && deal.isUserRepresentativeOrLead"
+        content="${deal.isRepresentativeUser ? 'IMPORTANT: You can withdraw your tokens at any time as this deal has failed.  Go To Withdraw to withdraw token deposits.' : null}"
+      >
+        <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
+          ${deal.isRepresentativeUser ? 'Go To Withdraw' : 'Go to Status'}
+          <i class="fas fa-arrow-right"></i>
+        </pbutton>
+      </status-action-bar>
     </swap-status>
     <!-- Discussions / Discussion Comments Thread -->
     <deal-discussion

--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -1,4 +1,5 @@
 <template>
+  <require from="../funding/swap-status/swap-status"></require>
   <require from="./dealMenubar/dealMenubar"></require>
   <require from="./dealVotes/dealVotes"></require>
   <require from="./dealInfo/dealInfo"></require>
@@ -6,9 +7,13 @@
   <require from="./dealDiscussion/dealDiscussion"></require>
   <require from="./dealMakeAnOffer/dealMakeAnOffer"></require>
   <require from="./dealDescription/dealDescription"></require>
+  <require from="./status-action-bar/status-action-bar"></require>
   <require from="../deals/timeLeft/timeLeft"></require>
 
-  <main data-test="deal-dashboard-container" class="page animated-page au-animate dealDashboardContainer">
+  <main
+    data-test="deal-dashboard-container"
+    class="page animated-page au-animate dealDashboardContainer"
+  >
     <deal-menubar deal.bind="deal"></deal-menubar>
 
     <section class="section top">
@@ -30,7 +35,8 @@
       <deal-info deal.bind="deal"></deal-info>
       <deal-make-an-offer
         deal.bind="deal"
-        if.bind="deal.isOpenProposal && !deal.isUserProposalLead"></deal-make-an-offer>
+        if.bind="deal.isOpenProposal && !deal.isUserProposalLead"
+      ></deal-make-an-offer>
     </aside>
 
     <deal-description deal.bind="deal"></deal-description>
@@ -39,13 +45,34 @@
       authorized.bind="isAllowedToDiscuss"
       deal.bind="deal"
       discussion-id.two-way="discussionId"
-      if.to-view="deal.isUserRepresentativeOrLead || !deal.isPrivate"></deal-clauses>
-
+      if.to-view="deal.isUserRepresentativeOrLead || !deal.isPrivate"
+    ></deal-clauses>
+    <swap-status deal.bind="deal" if.to-view="deal.primaryDao.tokens && deal.partnerDao">
+      <!-- Show this only when the deal is fully funded but before the swap has been executed -->
+      <status-action-bar
+        if.to-view="deal.isTargetReached && deal.isFunding"
+        content="IMPORTANT: Funding is complete so you must initiate swapping before the funding period expires in XXXX days."
+      >
+        <pbutton type="primary" click.delegate="executeSwap()" disabled.bind="isExecutingSwap">
+          Execute Swap <i class="fas">&#xf021;</i>
+        </pbutton>
+      </status-action-bar>
+      <!-- Show this only when the swap has been executed and the user is either the proposal lead or a representative -->
+      <status-action-bar
+        if.to-view="deal.isClaiming && deal.isUserRepresentativeOrLead"
+        content="IMPORTANT: Go to Claiming to claim vested tokens for your DAO."
+      >
+        <pbutton type="primary" click.delegate="router.navigate(`funding/${deal.id}`)">
+          Go to Claiming <i class="fas fa-arrow-right"></i>
+        </pbutton>
+      </status-action-bar>
+    </swap-status>
     <!-- Discussions / Discussion Comments Thread -->
     <deal-discussion
       authorized.bind="isAllowedToDiscuss"
       deal.bind="deal"
       discussion-id.two-way="discussionId"
-      show.bind="deal.isUserRepresentativeOrLead || !deal.isPrivate"></deal-discussion>
+      show.bind="deal.isUserRepresentativeOrLead || !deal.isPrivate"
+    ></deal-discussion>
   </main>
 </template>

--- a/src/dealDashboard/dealDashboard.scss
+++ b/src/dealDashboard/dealDashboard.scss
@@ -1,6 +1,51 @@
 @import "src/styles/styles.scss";
 @import "src/resources/elements/primeDesignSystem/styles";
+.ppopup-dialog.executeSwap {
+  p.dialogBody {
+    width: 550px;
+  }
+  .modal-content {
+    border-radius: 10px;
+    background-color: $BG02;
+    width: 100%;
+    padding: 20px;
+    margin-top: 40px;
+    display: grid;
+    grid-gap: 20px;
+    h6 {
+      text-transform: uppercase;
+      color: $Secondary02;
+      font-size: 14px;
+      font-weight: 700;
+      font-family: Aeonik;
+    }
+    .dao {
+      font-size: 14px;
+      color: #ffffff;
+      font-weight: 400;
+      font-family: Aeonik;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-column-gap: 10px;
+      .buttons {
+        display: flex;
+        column-gap: 4px;
+        align-items: center;
 
+        .etherscan-button {
+          outline: none;
+          path {
+            fill: $Secondary05;
+          }
+          cursor: pointer;
+          &:hover > path {
+            fill: $White;
+          }
+        }
+      }
+    }
+  }
+}
 .page.dealDashboardContainer {
   display: grid;
   grid-template-columns: auto 360px;
@@ -10,6 +55,7 @@
     "top top-extended"
     "description aside"
     "clauses aside"
+    "swapstatus swapstatus"
     "discussion discussion"
     "thread thread";
   gap: 0 115px;
@@ -27,7 +73,7 @@
     }
 
     time-left {
-      font-family: 'Inter';
+      font-family: "Inter";
       font-style: normal;
       font-weight: 700;
       font-size: 14px;
@@ -44,7 +90,10 @@
   deal-clauses {
     grid-area: clauses;
   }
-
+  .section.swap-status {
+    grid-area: swapstatus;
+    margin-top: 30px;
+  }
   deal-discussion {
     grid-area: discussion;
 
@@ -79,6 +128,7 @@
       "content"
       "clauses"
       "aside"
+      "swapstatus"
       "discussion";
     grid-row-gap: 50px;
     grid-column-gap: 0;
@@ -94,6 +144,7 @@
       "content"
       "clauses"
       "aside"
+      "swapstatus"
       "discussion";
   }
 }

--- a/src/dealDashboard/dealDashboard.scss
+++ b/src/dealDashboard/dealDashboard.scss
@@ -1,51 +1,6 @@
 @import "src/styles/styles.scss";
 @import "src/resources/elements/primeDesignSystem/styles";
-.ppopup-dialog.executeSwap {
-  p.dialogBody {
-    width: 550px;
-  }
-  .modal-content {
-    border-radius: 10px;
-    background-color: $BG02;
-    width: 100%;
-    padding: 20px;
-    margin-top: 40px;
-    display: grid;
-    grid-gap: 20px;
-    h6 {
-      text-transform: uppercase;
-      color: $Secondary02;
-      font-size: 14px;
-      font-weight: 700;
-      font-family: Aeonik;
-    }
-    .dao {
-      font-size: 14px;
-      color: #ffffff;
-      font-weight: 400;
-      font-family: Aeonik;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-column-gap: 10px;
-      .buttons {
-        display: flex;
-        column-gap: 4px;
-        align-items: center;
 
-        .etherscan-button {
-          outline: none;
-          path {
-            fill: $Secondary05;
-          }
-          cursor: pointer;
-          &:hover > path {
-            fill: $White;
-          }
-        }
-      }
-    }
-  }
-}
 .page.dealDashboardContainer {
   display: grid;
   grid-template-columns: auto 360px;
@@ -90,7 +45,7 @@
   deal-clauses {
     grid-area: clauses;
   }
-  .section.swap-status {
+  deal-swap-status {
     grid-area: swapstatus;
     margin-top: 30px;
   }

--- a/src/dealDashboard/dealDashboard.ts
+++ b/src/dealDashboard/dealDashboard.ts
@@ -7,6 +7,10 @@ import { EventAggregator } from "aurelia-event-aggregator";
 import { Router } from "aurelia-router";
 import { AureliaHelperService } from "../services/AureliaHelperService";
 import { DisposableCollection } from "../services/DisposableCollection";
+import { AlertService, IAlertModel, ShowButtonsEnum } from "services/AlertService";
+import { IDAO } from "entities/DealRegistrationTokenSwap";
+import { Utils } from "services/utils";
+import { EventConfig, EventMessageType } from "services/GeneralEvents";
 
 @autoinject
 export class DealDashboard {
@@ -14,13 +18,14 @@ export class DealDashboard {
   private discussionId: string = null;
   private dealId: string;
   private subscriptions = new DisposableCollection();
-
+  private isExecutingSwap = false;
   constructor(
     private ethereumService: EthereumService,
     private dealService: DealService,
     private eventAggregator: EventAggregator,
     private router: Router,
     private aureliaHelperService: AureliaHelperService,
+    private alertService: AlertService,
   ) {
   }
 
@@ -60,4 +65,73 @@ export class DealDashboard {
   public get userCanAccessDashboard(): boolean {
     return !this.deal.isPrivate || this.deal.isRepresentativeUser || this.deal.isUserProposalLead;
   }
+
+  /**
+   * Executes the token swap. Called by the "Execute Token Swap" button on the UI
+   *  - pops up a modal to verify the user wants to execute the swap
+   *  - does nothing if they hit cancel
+   *  - if they hit "execute" it will execute and show the congrats modal
+   */
+  public async executeSwap(): Promise<void> {
+    const swapModal: IAlertModel = {
+      header: "Execute token swap",
+      message:
+        `<p>You are about to execute token swapping between the following two DAOs. Do you want to execute these swaps?</p>
+        <div class='modal-content'>${this.getDaoHtmlForSwap(this.deal.primaryDao)}${this.getDaoHtmlForSwap(this.deal.partnerDao)}</div>`,
+      buttonTextPrimary: "Execute Swap <i style='margin-left:5px;' class='fa'>&#xf021;</i>",
+      buttonTextSecondary: "Cancel",
+      buttons: ShowButtonsEnum.Both,
+      className: "executeSwap",
+    };
+    // show a modal confirming the user wants to execute the swap
+    const dialogResult = await this.alertService.showAlert(swapModal);
+    if (!dialogResult.wasCancelled) {
+      this.isExecutingSwap = true;
+      //the user said they wanted to execute the swap so call the swap contract
+      const transactionReceipt = await this.deal.execute();
+      if (transactionReceipt){
+        //if the swap succeeded, show the 'congrats' modal
+        const congratulatePopupModel: IAlertModel = {
+          header: "Congratulations!",
+          message: "<p class='excitement'>You have successfully executed the token swap!</p>",
+          confetti: true,
+          buttonTextPrimary: "Close",
+          className: "congratulatePopup",
+        };
+        await this.alertService.showAlert(congratulatePopupModel);
+      } else {
+        this.eventAggregator.publish("handleError", new EventConfig("There was an error while attempting to execute the token swap. Please try again later", EventMessageType.Info, "Execute Swap Error"));
+      }
+      this.isExecutingSwap = false;
+    }
+  }
+
+  /**
+   * Gets the HTML for the dao token swap modal popup
+   * @param dao
+   * @returns string
+   */
+  private getDaoHtmlForSwap(dao: IDAO): string {
+    return `
+      <div>
+        <h6>${dao.name} treasury address</h6>
+        <div class="dao">
+          <address-link address="${dao.treasury_address}"
+              link-text="${dao.treasury_address}"
+              show-arrow-inside-link.bind="true"
+              show-tooltip.bind="false">
+            </address-link>
+        </div>
+      </div>
+      `;
+  }
+
+  /**
+   * Opens a new window to the transaction id or address on the blockchain
+   * @param address
+   * @param tx
+   */
+  private gotoEtherscan = (address: string, tx = false): void => {
+    Utils.goto(this.ethereumService.getEtherscanLink(address, tx));
+  };
 }

--- a/src/dealDashboard/dealDashboard.ts
+++ b/src/dealDashboard/dealDashboard.ts
@@ -7,10 +7,6 @@ import { EventAggregator } from "aurelia-event-aggregator";
 import { Router } from "aurelia-router";
 import { AureliaHelperService } from "../services/AureliaHelperService";
 import { DisposableCollection } from "../services/DisposableCollection";
-import { AlertService, IAlertModel, ShowButtonsEnum } from "services/AlertService";
-import { IDAO } from "entities/DealRegistrationTokenSwap";
-import { Utils } from "services/utils";
-import { EventConfig, EventMessageType } from "services/GeneralEvents";
 
 @autoinject
 export class DealDashboard {
@@ -18,14 +14,13 @@ export class DealDashboard {
   private discussionId: string = null;
   private dealId: string;
   private subscriptions = new DisposableCollection();
-  private isExecutingSwap = false;
+
   constructor(
     private ethereumService: EthereumService,
     private dealService: DealService,
     private eventAggregator: EventAggregator,
     private router: Router,
     private aureliaHelperService: AureliaHelperService,
-    private alertService: AlertService,
   ) {
   }
 
@@ -56,10 +51,6 @@ export class DealDashboard {
         this.eventAggregator.publish("showMessage", "Deal privacy has been successfully submitted");
       }),
     );
-    //wait until the dao transactions from the contract are there
-    await Utils.waitUntilTrue(() => this.deal.daoTokenTransactions !== undefined);
-    //wait until the dao token claims from the contract are there
-    await Utils.waitUntilTrue(() => this.deal.daoTokenClaims !== undefined);
   }
 
   public detached() {
@@ -70,72 +61,4 @@ export class DealDashboard {
     return !this.deal.isPrivate || this.deal.isRepresentativeUser || this.deal.isUserProposalLead;
   }
 
-  /**
-   * Executes the token swap. Called by the "Execute Token Swap" button on the UI
-   *  - pops up a modal to verify the user wants to execute the swap
-   *  - does nothing if they hit cancel
-   *  - if they hit "execute" it will execute and show the congrats modal
-   */
-  public async executeSwap(): Promise<void> {
-    const swapModal: IAlertModel = {
-      header: "Execute token swap",
-      message:
-        `<p>You are about to execute token swapping between the following two DAOs. Do you want to execute these swaps?</p>
-        <div class='modal-content'>${this.getDaoHtmlForSwap(this.deal.primaryDao)}${this.getDaoHtmlForSwap(this.deal.partnerDao)}</div>`,
-      buttonTextPrimary: "Execute Swap <i style='margin-left:5px;' class='fa'>&#xf021;</i>",
-      buttonTextSecondary: "Cancel",
-      buttons: ShowButtonsEnum.Both,
-      className: "executeSwap",
-    };
-    // show a modal confirming the user wants to execute the swap
-    const dialogResult = await this.alertService.showAlert(swapModal);
-    if (!dialogResult.wasCancelled) {
-      this.isExecutingSwap = true;
-      //the user said they wanted to execute the swap so call the swap contract
-      const transactionReceipt = await this.deal.execute();
-      if (transactionReceipt){
-        //if the swap succeeded, show the 'congrats' modal
-        const congratulatePopupModel: IAlertModel = {
-          header: "Congratulations!",
-          message: "<p class='excitement'>You have successfully executed the token swap!</p>",
-          confetti: true,
-          buttonTextPrimary: "Close",
-          className: "congratulatePopup",
-        };
-        await this.alertService.showAlert(congratulatePopupModel);
-      } else {
-        this.eventAggregator.publish("handleError", new EventConfig("There was an error while attempting to execute the token swap. Please try again later", EventMessageType.Info, "Execute Swap Error"));
-      }
-      this.isExecutingSwap = false;
-    }
-  }
-
-  /**
-   * Gets the HTML for the dao token swap modal popup
-   * @param dao
-   * @returns string
-   */
-  private getDaoHtmlForSwap(dao: IDAO): string {
-    return `
-      <div>
-        <h6>${dao.name} treasury address</h6>
-        <div class="dao">
-          <address-link address="${dao.treasury_address}"
-              link-text="${dao.treasury_address}"
-              show-arrow-inside-link.bind="true"
-              show-tooltip.bind="false">
-            </address-link>
-        </div>
-      </div>
-      `;
-  }
-
-  /**
-   * Opens a new window to the transaction id or address on the blockchain
-   * @param address
-   * @param tx
-   */
-  private gotoEtherscan = (address: string, tx = false): void => {
-    Utils.goto(this.ethereumService.getEtherscanLink(address, tx));
-  };
 }

--- a/src/dealDashboard/status-action-bar/status-action-bar.html
+++ b/src/dealDashboard/status-action-bar/status-action-bar.html
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <p if.to-view="content">
+      <i class="fas fa-info-circle"></i>
+      <span>${content}</span>
+    </p>
+    <slot></slot>
+  </div>
+</template>

--- a/src/dealDashboard/status-action-bar/status-action-bar.scss
+++ b/src/dealDashboard/status-action-bar/status-action-bar.scss
@@ -1,5 +1,7 @@
+@import "styles/styles.scss";
+@import "src/resources/elements/primeDesignSystem/styles";
 @import "src/resources/elements/primeDesignSystem/variables";
-
+@import "src/resources/elements/primeDesignSystem/colors";
 status-action-bar {
   margin-top: 40px;
   display: grid;
@@ -7,7 +9,7 @@ status-action-bar {
   div {
     display: grid;
     grid-template-columns: 350px auto;
-    grid-column-gap: 20px;
+    grid-gap: 20px;
     place-items: center;
     pbutton {
       i {
@@ -49,6 +51,16 @@ status-action-bar {
         line-height: 17px;
         font-size: 14px;
       }
+    }
+  }
+  @media screen and (max-width: $MaxContentBodyWidthMobile) {
+    div {
+      grid-template-columns: 1fr;
+    }
+  }
+  @media screen and (max-width: $MaxContentBodyWidth) {
+    div {
+      grid-template-columns: 1fr;
     }
   }
 }

--- a/src/dealDashboard/status-action-bar/status-action-bar.scss
+++ b/src/dealDashboard/status-action-bar/status-action-bar.scss
@@ -7,7 +7,7 @@ status-action-bar {
   div {
     display: grid;
     grid-template-columns: 350px auto;
-    grid-column-gap: 10px;
+    grid-column-gap: 20px;
     place-items: center;
     pbutton {
       i {

--- a/src/dealDashboard/status-action-bar/status-action-bar.scss
+++ b/src/dealDashboard/status-action-bar/status-action-bar.scss
@@ -1,0 +1,37 @@
+@import "src/resources/elements/primeDesignSystem/variables";
+
+status-action-bar {
+  margin-top: 40px;
+  display: grid;
+  place-items: center;
+  div {
+    display: grid;
+    grid-template-columns: 350px auto;
+    grid-column-gap: 10px;
+    place-items: center;
+    pbutton {
+      i {
+        margin-left: 10px;
+      }
+    }
+    p {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      grid-gap: 12px;
+      max-width: 350px;
+
+      i {
+        font-size: 20px;
+        color: $Orange;
+      }
+      span {
+        margin-top: -3px;
+        font-weight: 400;
+        font-family: Inter;
+        color: $White;
+        line-height: 17px;
+        font-size: 14px;
+      }
+    }
+  }
+}

--- a/src/dealDashboard/status-action-bar/status-action-bar.ts
+++ b/src/dealDashboard/status-action-bar/status-action-bar.ts
@@ -1,0 +1,6 @@
+import "./status-action-bar.scss";
+import { bindable } from "aurelia-framework";
+
+export class StatusActionBar {
+  @bindable content: string;
+}

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -81,9 +81,9 @@ export interface ITokenCalculated extends IToken {
   deposited?: BigNumber,
   required?: BigNumber,
   percentCompleted?: number,
-  claimable: BigNumber,
-  claimed: BigNumber,
-  locked: BigNumber,
+  claimable?: BigNumber,
+  claimed?: BigNumber,
+  locked?: BigNumber,
 }
 
 @autoinject

--- a/src/entities/TokenFunding.ts
+++ b/src/entities/TokenFunding.ts
@@ -1,8 +1,0 @@
-import { BigNumber } from "ethers";
-import { IToken } from "./DealRegistrationTokenSwap";
-
-export interface ITokenFunding extends IToken {
-  deposited?: BigNumber,
-  required?: BigNumber,
-  percentCompleted?: number
-}

--- a/src/funding/deposit-grid/deposit-grid.html
+++ b/src/funding/deposit-grid/deposit-grid.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="box-header">
+  <div class="box-header deposit-grid">
     <div class="heading heading3 title gradient">${dao.name} Deposit</div>
     <pchip
       color="${fundingDaysLeft >= 10 ? 'warning' : 'danger'}"
@@ -9,7 +9,7 @@
     </pchip>
     <pchip color="danger" if.to-view="showChip && deal.isFailed">Target not reached</pchip>
   </div>
-  <div class="box-content">
+  <div class="box-content deposit-grid">
     <div class="tokens">
       <pgrid
         id="token-grid"

--- a/src/funding/deposit-grid/deposit-grid.scss
+++ b/src/funding/deposit-grid/deposit-grid.scss
@@ -2,101 +2,97 @@
 @import "src/resources/elements/primeDesignSystem/styles";
 @import "src/resources/elements/primeDesignSystem/variables";
 @import "src/resources/elements/primeDesignSystem/colors";
-.deposit {
-  .box-container {
-    .box-header {
-      padding-bottom: 10px;
-      padding-top: 20px;
-      display: grid;
-      grid-template-columns: 1fr auto;
-    }
-    .box-content {
-      .tokens {
-        .grid {
-          margin-bottom: 20px;
-          font-size: 16px;
+.box-header.deposit-grid {
+  padding-bottom: 10px;
+  padding-top: 20px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+.box-content.deposit-grid {
+  .tokens {
+    .grid {
+      margin-bottom: 20px;
+      font-size: 16px;
 
-          .row {
-            cursor: default;
-            /**
+      .row {
+        cursor: default;
+        /**
                * so the grid will be composed of the contents of the row element,
                * not the row element itself.
                */
-            display: contents;
+        display: contents;
 
-            &:hover {
-              text-decoration: none;
-            }
+        &:hover {
+          text-decoration: none;
+        }
 
-            .cell.header {
-              padding: 10px 0;
-              text-transform: uppercase;
-            }
+        .cell.header {
+          padding: 10px 0;
+          text-transform: uppercase;
+        }
 
-            .cell {
-              &.body {
-                height: 40px;
-                display: flex;
-                align-items: center;
-              }
-              /**
+        .cell {
+          &.body {
+            height: 40px;
+            display: flex;
+            align-items: center;
+          }
+          /**
                  * for when columns get scrunched together
                  */
-              &:not(:nth-of-type(n + 7)) {
-                padding-right: 12px;
-              }
+          &:not(:nth-of-type(n + 7)) {
+            padding-right: 12px;
+          }
 
-              &.header {
-                &.sortable {
-                  cursor: pointer;
-                }
-              }
+          &.header {
+            &.sortable {
+              cursor: pointer;
+            }
+          }
 
-              &.project {
-                .ellipsesContainer {
-                  display: inline-block;
-                  overflow-x: hidden;
-                  text-overflow: ellipsis;
-                }
-              }
+          &.project {
+            .ellipsesContainer {
+              display: inline-block;
+              overflow-x: hidden;
+              text-overflow: ellipsis;
+            }
+          }
 
-              &.percent {
-                text-align: right;
-                justify-content: right;
-              }
+          &.percent {
+            text-align: right;
+            justify-content: right;
+          }
 
-              &.projectToken,
-              &.fundingToken {
-                white-space: nowrap;
+          &.projectToken,
+          &.fundingToken {
+            white-space: nowrap;
 
-                img {
-                  margin-right: 6px;
-                  @include tokenIcon;
-                }
-              }
+            img {
+              margin-right: 6px;
+              @include tokenIcon;
+            }
+          }
 
-              &.starts {
-                .timeLeftContainer {
-                  .body {
-                    font-family: Aeonik; // so will center properly and look consistent
-                  }
-                }
-              }
-              &.eslink {
-                i {
-                  cursor: pointer;
-                  color: $Secondary02;
-                }
+          &.starts {
+            .timeLeftContainer {
+              .body {
+                font-family: Aeonik; // so will center properly and look consistent
               }
             }
           }
-        }
-
-        #token-grid {
-          .required {
-            color: $Orange;
+          &.eslink {
+            i {
+              cursor: pointer;
+              color: $Secondary02;
+            }
           }
         }
+      }
+    }
+
+    #token-grid {
+      .required {
+        color: $Orange;
       }
     }
   }

--- a/src/funding/funding-grid-columns.ts
+++ b/src/funding/funding-grid-columns.ts
@@ -33,10 +33,10 @@ export const depositColumns: IGridColumn[] = [
 
 export const tokenGridColumns: IGridColumn[] = [
   { field: "name", sortable: true, width: ".5fr", headerText: "token", template: "<dao-icon-name primary-dao.to-view=\"row\" icon-size=\"24\" use-token-symbol.to-view=\"true\"></dao-icon-name>" },
-  { field: "target", sortable: true, width: ".5fr", template: "${target | ethwei:row.decimals}" },
+  { field: "target", sortable: true, width: ".5fr", template: "${amount | ethwei:row.decimals}" },
   { field: "deposited", sortable: true, width: ".5fr", template: "${deposited | ethwei:row.decimals}" },
   { field: "required", sortable: true, width: ".5fr", template: "<div class='required'>${required | ethwei:row.decimals}</div>" },
-  { field: "percentCompleted", sortable: true, headerText: "Completed", width: "1fr", template: "<pprogress-bar  style='height: 10px; width: 100%'  max.bind='target'  current.bind='deposited'></pprogress-bar>" },
+  { field: "percentCompleted", sortable: true, headerText: "Completed", width: "1fr", template: "<pprogress-bar  style='height: 10px; width: 100%'  max.bind='amount'  current.bind='deposited'></pprogress-bar>" },
   { field: "percentCompleted", sortable: true, align: "right", headerText: "%", width: ".2fr", template: "${percentCompleted}%" },
 ];
 

--- a/src/funding/funding-grid-columns.ts
+++ b/src/funding/funding-grid-columns.ts
@@ -41,8 +41,8 @@ export const tokenGridColumns: IGridColumn[] = [
 ];
 
 export const claimTokenGridColumns: IGridColumn[] = [
-  { field: "token", sortable: true, width: ".5fr", template: "<dao-icon-name primary-dao.to-view=\"row.token\" icon-size=\"24\" use-token-symbol.to-view=\"true\"></dao-icon-name>" },
-  { field: "claimable", sortable: true, width: ".5fr", align: "right", template: "${withCommas(claimable) | ethwei:row.decimals}" },
-  { field: "locked", sortable: true, width: ".5fr", align: "right", template: "${withCommas(locked) | ethwei:row.decimals}" },
-  { field: "total", sortable: true, width: ".5fr", align: "right", template: "${withCommas(claimable + locked) | ethwei:row.decimals}" },
+  { field: "token", headerText: "Token", sortable: true, width: ".5fr", template: "<dao-icon-name primary-dao.to-view=\"row.token\" icon-size=\"24\" use-token-symbol.to-view=\"true\"></dao-icon-name>" },
+  { field: "claimable", headerText: "Claimable", sortable: true, width: ".5fr", align: "right", template: "${withCommas(claimable) | ethwei:row.decimals}" },
+  { field: "locked", headerText: "Locked", sortable: true, width: ".5fr", align: "right", template: "${withCommas(locked) | ethwei:row.decimals}" },
+  { field: "amount", headerText: "Total", sortable: true, width: ".5fr", align: "right", template: "${withCommas(amount) | ethwei:row.decimals}" },
 ];

--- a/src/funding/funding.html
+++ b/src/funding/funding.html
@@ -109,11 +109,6 @@
       </div>
     </section>
     <swap-status deal.bind="deal">
-      <div class="section execute-swap" if.to-view="deal.isTargetReached">
-        <pbutton type="primary" click.delegate="executeSwap()">
-          Execute swap <i class="fas">&#xf021;</i>
-        </pbutton>
-      </div>
       <div class="claim-tokens" if.to-view="deal.isClaiming">
         <div class="box-container">
           <div>

--- a/src/funding/funding.html
+++ b/src/funding/funding.html
@@ -28,7 +28,7 @@
         ></deposit-grid>
         <div class="container-footer">
           <let
-            is-rep-and-deal-still-funding.bind="deal.isRepresentativeUser && !deal.isTargetReached && !deal.isFailed"
+            show-deposit-form.bind="deal.isRepresentativeUser && !deal.isTargetReached && !deal.isFailed"
           ></let>
           <div class="contracts">
             <p>
@@ -43,7 +43,7 @@
                 given period of time. The representatives can withdraw their funds at any time.
                 Their funds are secured.
               </span>
-              <span if.to-view="isRepAndDealStillFunding">
+              <span if.to-view="showDepositForm">
                 You're depositing on behalf of ${deal.firstDao.name}. This deal needs to be funded
                 and executed within ${fundingDaysLeft} days.
               </span>
@@ -58,7 +58,7 @@
               </span>
             </p>
           </div>
-          <div class="deposit" if.to-view="isRepAndDealStillFunding">
+          <div class="deposit" if.to-view="showDepositForm">
             <div class="form">
               <div>
                 <div class="inputs">
@@ -96,7 +96,7 @@
               >
             </div>
           </div>
-          <div class="links ${deal.isUserProposalLead ? 'right' : ''}">
+          <div class="links ${!deal.isRepresentativeUser ? 'right' : ''}">
             <address-link
               address.to-view="deal.daoDepositContracts.get(deal.firstDao).address"
               link-text="DAODepositManager Contract"
@@ -132,7 +132,7 @@
               >
               </pgrid>
             </div>
-            <div class="token-grid">
+            <div class="token-grid" if.to-view="deal.isUserProposalLead">
               <h4 class="title heading heading3 gradient">
                 Vested Token Status of ${secondDao.name}
               </h4>
@@ -149,7 +149,7 @@
             <p>
               <i class="fas fa-info-circle"></i>
               <span>
-                ${!deal.isRepresentativeUser ? 'Representatitves of each' : 'Your'} DAO will be able
+                ${deal.isRepresentativeUser ? 'Your' : 'Representatitves of each'} DAO will be able
                 to claim vested tokens once they are claimable.
               </span>
             </p>

--- a/src/funding/funding.html
+++ b/src/funding/funding.html
@@ -18,7 +18,7 @@
         <deposit-grid
           dao.bind="firstDao"
           dao-tokens.bind="firstDaoTokens"
-          funding-days-left.bind="fundingDaysLeft"
+          funding-days-left="${(deal.timeLeftToExecute / (60*60*24*1000)).toFixed(0)}"
         ></deposit-grid>
         <deposit-grid
           if.to-view="deal.isUserProposalLead"
@@ -45,13 +45,13 @@
               </span>
               <span if.to-view="showDepositForm">
                 You're depositing on behalf of ${deal.firstDao.name}. This deal needs to be funded
-                and executed within ${fundingDaysLeft} days.
+                and executed within ${deal.timeLeftToExecute | timespan:'largest2'} days.
               </span>
               <span
                 if.to-view="!deal.isFailed && !deal.isTargetReached && !deal.isRepresentativeUser"
               >
-                This deal needs to be funded and executed within ${fundingDaysLeft} days. Only
-                representatives can deposit the tokens.
+                This deal needs to be funded and executed within ${deal.timeLeftToExecute |
+                timespan:'largest2'} days. Only representatives can deposit the tokens.
               </span>
               <span if.to-view="!deal.isFailed && deal.isTargetReached">
                 All parties have deposited their funds. You may now execute the deal.

--- a/src/funding/funding.html
+++ b/src/funding/funding.html
@@ -116,7 +116,7 @@
               <h4 class="title heading heading3 gradient">Claim Tokens for ${firstDao.name}</h4>
               <pgrid
                 id="token-grid"
-                rows.bind="firstDaoTokensToClaim"
+                rows.bind="firstDaoTokens"
                 columns.bind="claimTokenGridColumns"
                 condensed.bind="true"
               >
@@ -126,7 +126,7 @@
               <h4 class="title heading heading3 gradient">Claim Tokens for ${secondDao.name}</h4>
               <pgrid
                 id="token-grid"
-                rows.bind="secondDaoTokensToClaim"
+                rows.bind="secondDaoTokens"
                 columns.bind="claimTokenGridColumns"
                 condensed.bind="true"
               >

--- a/src/funding/funding.scss
+++ b/src/funding/funding.scss
@@ -6,61 +6,11 @@
 $hover-transition-speed-fast: 175ms;
 $hover-transition-speed-medium: 0.3s;
 $hover-transition-speed-slow: 0.4s;
-.ppopup-dialog.executeSwap {
-  p.dialogBody {
-    width: 550px;
-  }
-  .modal-content {
-    border-radius: 10px;
-    background-color: $BG02;
-    width: 100%;
-    padding: 20px;
-    margin-top: 40px;
-    display: grid;
-    grid-gap: 20px;
-    h6 {
-      text-transform: uppercase;
-      color: $Secondary02;
-      font-size: 14px;
-      font-weight: 700;
-      font-family: Aeonik;
-    }
-    .dao {
-      font-size: 14px;
-      color: #ffffff;
-      font-weight: 400;
-      font-family: Aeonik;
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-column-gap: 10px;
-      .buttons {
-        display: flex;
-        column-gap: 4px;
-        align-items: center;
-
-        .etherscan-button {
-          outline: none;
-          path {
-            fill: $Secondary05;
-          }
-          cursor: pointer;
-          &:hover > path {
-            fill: $White;
-          }
-        }
-      }
-    }
-  }
-}
 .success {
   color: $Green;
 }
 .danger {
   color: $Red;
-}
-.progress-bar {
-  height: 10px;
-  width: 100%;
 }
 .page.fundContainer {
   section {

--- a/src/funding/funding.ts
+++ b/src/funding/funding.ts
@@ -120,15 +120,6 @@ export class Funding {
   }
 
   /**
-   * Returns a relative time with a custom replacer
-   * @param dateTime
-   * @returns string
-   */
-  public getFormattedTime = (dateTime: Date, locale = "en-custom"): string => {
-    return this.dateService.formattedTime(dateTime).diff(locale, false);
-  };
-
-  /**
    * Gets the icon name for the transaction type
    * @param type
    * @returns string
@@ -314,18 +305,6 @@ export class Funding {
     // this.deposits = deposits;
     // return;
     this.deposits = [...this.mapTransactionsToDeposits(this.deal.daoTokenTransactions.get(this.firstDao)), ...this.mapTransactionsToDeposits(this.deal.daoTokenTransactions.get(this.secondDao))].sort((a, b) => b.createdAt < a.createdAt ? 1 : -1);
-  }
-
-  @computedFrom("deal.executedAt", "deal.fundingPeriod")
-  public get fundingDaysLeft() : number {
-    if (this.deal.executedAt && this.deal.fundingPeriod) {
-      const executionTime = this.deal.executedAt;
-      executionTime.setSeconds(executionTime.getSeconds() + this.deal.fundingPeriod);
-      const finalDate = moment(executionTime);
-      const now = moment();
-      return finalDate.diff(now, "days");
-    }
-    return 0;
   }
 
   @computedFrom("firstDaoTokens")

--- a/src/funding/funding.ts
+++ b/src/funding/funding.ts
@@ -17,7 +17,6 @@ import { autoinject, computedFrom } from "aurelia-framework";
 import { IDAO } from "entities/DealRegistrationTokenSwap";
 import { IPSelectItemConfig } from "resources/elements/primeDesignSystem/pselect/pselect";
 import { observable } from "aurelia-typed-observable-plugin";
-import moment from "moment-timezone";
 import { IAlertModel } from "services/AlertService";
 import { IGridColumn } from "resources/elements/primeDesignSystem/pgrid/pgrid";
 import { depositColumns, claimTokenGridColumns } from "./funding-grid-columns";

--- a/src/funding/funding.ts
+++ b/src/funding/funding.ts
@@ -1,7 +1,7 @@
 import { TokenService } from "services/TokenService";
 import { AlertService, ShowButtonsEnum } from "./../services/AlertService";
 import { NumberService } from "./../services/NumberService";
-import { IDaoTransaction } from "./../entities/DealTokenSwap";
+import { IDaoTransaction, ITokenCalculated } from "./../entities/DealTokenSwap";
 import { DateService } from "services/DateService";
 import { EventMessageType } from "./../resources/elements/primeDesignSystem/types";
 import { EventConfig, EventConfigException } from "./../services/GeneralEvents";
@@ -14,8 +14,7 @@ import { EthereumService } from "services/EthereumService";
 import { Router } from "aurelia-router";
 import { Utils } from "services/utils";
 import { autoinject, computedFrom } from "aurelia-framework";
-import { IDAO, IToken } from "entities/DealRegistrationTokenSwap";
-import { ITokenFunding } from "entities/TokenFunding";
+import { IDAO } from "entities/DealRegistrationTokenSwap";
 import { IPSelectItemConfig } from "resources/elements/primeDesignSystem/pselect/pselect";
 import { observable } from "aurelia-typed-observable-plugin";
 import moment from "moment-timezone";
@@ -24,11 +23,6 @@ import { IGridColumn } from "resources/elements/primeDesignSystem/pgrid/pgrid";
 import { depositColumns, claimTokenGridColumns } from "./funding-grid-columns";
 import { AureliaHelperService } from "services/AureliaHelperService";
 
-export interface IDaoClaimToken {
-  token: IToken, //only need iconURI, symbol and decimals
-  claimable: number,
-  locked: number
-}
 @autoinject
 export class Funding {
   private depositColumns: IGridColumn[] = depositColumns;
@@ -45,8 +39,8 @@ export class Funding {
   private tokenDepositContractUrl = "";
   private tokenSwapModuleContractUrl = "";
   private vestedAmount = 0;
-  private secondDaoTokens: ITokenFunding[];
-  private firstDaoTokens: ITokenFunding[];
+  private secondDaoTokens: ITokenCalculated[];
+  private firstDaoTokens: ITokenCalculated[];
   private deposits: IDaoTransaction[] = [];
   /**
    * Opens a new window to the transaction id or address on the blockchain
@@ -90,8 +84,8 @@ export class Funding {
 
   public async bind(): Promise<void> {
     //get contract token information from the other DAO
-    //Clone the tokens from registration data and add props from ITokenFunding
-    this.secondDaoTokens = Utils.cloneDeep(this.secondDao.tokens);
+    //Clone the tokens from registration data and add props from ITokenCalculated
+    this.secondDaoTokens = Utils.cloneDeep(this.secondDao.tokens as ITokenCalculated[]);
     this.secondDaoTokens.forEach(x => {this.deal.setTokenContractInfo(x, this.secondDao);});
 
     //TODO figure out what the vested amount is from the deal
@@ -99,7 +93,7 @@ export class Funding {
     this.vestedAmount = 0;
 
     //get contract token information from the DAO related to the account
-    this.firstDaoTokens = Utils.cloneDeep(this.firstDao.tokens);
+    this.firstDaoTokens = Utils.cloneDeep(this.firstDao.tokens as ITokenCalculated[]);
     this.firstDaoTokens.forEach(x => {this.deal.setTokenContractInfo(x, this.firstDao);});
 
     if (this.firstDaoTokens.length === 1) {
@@ -213,7 +207,7 @@ export class Funding {
     await this.setAccountBalance(); // get the most up to date account balance to make sure it has enough
     //rebind token data if it's changed
     //TODO reset all the data after checking
-    // const token = this.firstDaoTokens[this.selectedToken] as ITokenFunding;
+    // const token = this.firstDaoTokens[this.selectedToken] as ITokenCalculated;
     // token.required = recentRequiredTokens;
     // token.deposited = converter.fromView(120);
     // token.target = converter.fromView(120);
@@ -348,23 +342,6 @@ export class Funding {
       text: x.symbol,
       innerHTML: `<span><img src="${x.logoURI}" style="width: 24px;height: 24px;margin-right: 10px;" /> ${x.symbol}</span>`,
       value: index.toString(),
-    }));
-  }
-
-  @computedFrom("firstDaoTokens")
-  public get firstDaoTokensToClaim() : IDaoClaimToken[]{
-    return this.firstDaoTokens.map(x => ({
-      token: x,
-      claimable: 1,
-      locked: 2,
-    }));
-  }
-  @computedFrom("secondDaoTokens")
-  public get secondDaoTokensToClaim() : IDaoClaimToken[]{
-    return this.secondDaoTokens.map(x => ({
-      token: x,
-      claimable: 21,
-      locked: 51,
     }));
   }
 

--- a/src/funding/funding.ts
+++ b/src/funding/funding.ts
@@ -38,7 +38,6 @@ export class Funding {
   private selectedToken: number | string;
   private tokenDepositContractUrl = "";
   private tokenSwapModuleContractUrl = "";
-  private vestedAmount = 0;
   private secondDaoTokens: ITokenCalculated[];
   private firstDaoTokens: ITokenCalculated[];
   private deposits: IDaoTransaction[] = [];
@@ -88,17 +87,13 @@ export class Funding {
     this.secondDaoTokens = Utils.cloneDeep(this.secondDao.tokens as ITokenCalculated[]);
     this.secondDaoTokens.forEach(async x => {await this.deal.setTokenContractInfo(x, this.secondDao);});
 
-    //TODO figure out what the vested amount is from the deal
-    //this.vestedAmount = this.deal.vestedAmount;
-    this.vestedAmount = 0;
-
     //get contract token information from the DAO related to the account
     this.firstDaoTokens = Utils.cloneDeep(this.firstDao.tokens as ITokenCalculated[]);
     this.firstDaoTokens.forEach(async x => {await this.deal.setTokenContractInfo(x, this.firstDao);});
 
     if (this.firstDaoTokens.length === 1) {
       //if there is only one token, auto select it in the deposit form
-      this.selectedToken = 0;
+      this.selectedToken = "0";
       //and get the account balance for that token
       await this.setAccountBalance();
     }
@@ -275,10 +270,7 @@ export class Funding {
    */
   private verifySecurity(): void {
     if (!this.deal || !this.deal.registrationData) return;
-    if (!this.deal.registrationData.primaryDAO.representatives.some(x => x.address === this.ethereumService.defaultAccountAddress) &&
-      !this.deal.registrationData.partnerDAO.representatives.some(x => x.address === this.ethereumService.defaultAccountAddress) &&
-      !this.deal.isUserProposalLead
-    ) {
+    if (!this.deal.isUserRepresentativeOrLead){
       //redirect user to the home page if not the proposal lead or one of the deal's representatives
       this.router.navigate("home");
     }
@@ -352,11 +344,11 @@ export class Funding {
 
   //moving this getter locally for the proposal lead
   public get firstDao() : IDAO{
-    return this.deal.isUserProposalLead ? this.deal.primaryDao : this.deal.daoRepresentedByCurrentAccount;
+    return this.deal.isRepresentativeUser ? this.deal.daoRepresentedByCurrentAccount : this.deal.primaryDao;
   }
 
   //moving this getter locally for the proposal lead
   public get secondDao() : IDAO {
-    return this.deal.isUserProposalLead ? this.deal.partnerDao : this.deal.daoOtherThanRepresentedByCurrentAccount;
+    return this.deal.isRepresentativeUser ? this.deal.daoOtherThanRepresentedByCurrentAccount : this.deal.partnerDao;
   }
 }

--- a/src/funding/status-card/status-card.html
+++ b/src/funding/status-card/status-card.html
@@ -7,31 +7,35 @@
       <pchip color="${chipColor}"> ${status} </pchip>
     </header>
     <div class="content">
-      <div class="token-progress" repeat.for="token of dao.tokens" if.to-view="!swapCompleted">
+      <div class="token-progress" repeat.for="token of tokens" if.to-view="!swapCompleted">
         <img src="${token.logoURI}" />
         <div>
           <div class="progress-bar-content">
             <div>
               <formatted-number
-                if.bind="token.deposited >= 0"
                 thousands-separated
                 value.to-view="token.deposited | ethwei:token.decimals"
               ></formatted-number>
               <strong>${token.symbol}</strong> Deposited
             </div>
-            <div>${token.percentCompleted}%</div>
+            <div>
+              <formatted-number
+                thousands-separated
+                value.to-view="token.percentCompleted"
+              ></formatted-number
+              >%
+            </div>
           </div>
           <div class="progress-bar">
-            <pprogress-bar max.bind="token.target" current.bind="token.deposited"></pprogress-bar>
+            <pprogress-bar max.bind="token.amount" current.bind="token.deposited"></pprogress-bar>
           </div>
         </div>
       </div>
       <div class="token-completed" if.to-view="swapCompleted">
-        <div repeat.for="token of dao.tokens">
+        <div repeat.for="token of tokens">
           <img src="${token.logoURI}" />
           <span
             ><formatted-number
-              if.bind="token.deposited >= 0"
               thousands-separated
               value.to-view="token.deposited | ethwei:token.decimals"
             ></formatted-number>

--- a/src/funding/status-card/status-card.scss
+++ b/src/funding/status-card/status-card.scss
@@ -17,6 +17,10 @@ pcard {
         color: $Neutral04;
       }
     }
+    .progress-bar {
+      height: 10px;
+      width: 100%;
+    }
     .content {
       display: grid;
       grid-template-columns: 1fr;

--- a/src/funding/status-card/status-card.ts
+++ b/src/funding/status-card/status-card.ts
@@ -7,6 +7,7 @@ import { DealStatus } from "entities/IDealTypes";
 @containerless
 export class StatusCard {
   @bindable dao: IDAO;
+  @bindable tokens: ITokenFunding[];
   @bindable swapCompleted: boolean;
   @bindable fundingFailed: boolean;
   private dealStatuses = DealStatus; //have to assign this to a view model field for the HTML to be able to compare enums
@@ -16,7 +17,7 @@ export class StatusCard {
     if (this.swapCompleted){
       return "success";
     }
-    if (this.dao.tokens.every((x: ITokenFunding) => x.required?.lte(0))){
+    if (this.tokens.every((x: ITokenFunding) => x.required?.lte(0))){
       return "success";
     } else {
       return this.fundingFailed ? "danger" : "warning";
@@ -28,7 +29,7 @@ export class StatusCard {
     if (this.swapCompleted){
       return "Swap completed"; //TODO why is there no status in DealStatus for "Swap Completed"?
     }
-    if (this.dao.tokens.every((x: ITokenFunding) => x.required?.lte(0))){
+    if (this.tokens.every((x: ITokenFunding) => x.required?.lte(0))){
       return "Target reached"; //DealStatus.completed; //TODO why is there no status in DealStatus for "Target Reached"?
     } else {
       return this.fundingFailed ? "Target not reached" : "Funding in progress"; //DealStatus.funding; //TODO why is there no status in DealStatus for "Funding in progress"?

--- a/src/funding/status-card/status-card.ts
+++ b/src/funding/status-card/status-card.ts
@@ -1,38 +1,47 @@
+import { DealTokenSwap, ITokenCalculated } from "entities/DealTokenSwap";
 import "./status-card.scss";
 import { containerless, bindable, computedFrom } from "aurelia-framework";
 import { IDAO } from "entities/DealRegistrationTokenSwap";
-import { ITokenFunding } from "entities/TokenFunding";
-import { DealStatus } from "entities/IDealTypes";
-
 @containerless
 export class StatusCard {
+  @bindable deal: DealTokenSwap;
   @bindable dao: IDAO;
-  @bindable tokens: ITokenFunding[];
-  @bindable swapCompleted: boolean;
-  @bindable fundingFailed: boolean;
-  private dealStatuses = DealStatus; //have to assign this to a view model field for the HTML to be able to compare enums
+  @bindable tokens: ITokenCalculated[] | I;
+
+  public bind(){
+
+  }
 
   @computedFrom("swapCompleted", "dao")
   get chipColor(): string{
     if (this.swapCompleted){
       return "success";
     }
-    if (this.tokens.every((x: ITokenFunding) => x.required?.lte(0))){
+    if (this.tokens.every((x: ITokenCalculated) => x.required?.lte(0))){
       return "success";
     } else {
-      return this.fundingFailed ? "danger" : "warning";
+      return this.deal.isFailed ? "danger" : "warning";
     }
   }
 
   @computedFrom("swapCompleted", "dao")
-  get status(): DealStatus | string{
+  get status(): string{
     if (this.swapCompleted){
-      return "Swap completed"; //TODO why is there no status in DealStatus for "Swap Completed"?
+      return "Swap completed";
+    } else if (this.deal.isClaiming){
+      //TODO check this dao to see if any tokens aren't fully claimed and return the status text for it
+      return "Swapping in completed";
     }
-    if (this.tokens.every((x: ITokenFunding) => x.required?.lte(0))){
-      return "Target reached"; //DealStatus.completed; //TODO why is there no status in DealStatus for "Target Reached"?
+    if (this.tokens.every((x: ITokenCalculated) => x.required?.lte(0))){
+      //TODO check this dao to see if any tokens aren't fully funded and return the status text for it
+      return "Target reached";
     } else {
-      return this.fundingFailed ? "Target not reached" : "Funding in progress"; //DealStatus.funding; //TODO why is there no status in DealStatus for "Funding in progress"?
+      return this.deal.isFailed ? "Target not reached" : "Funding in progress"; //DealStatus.funding; //TODO why is there no status in DealStatus for "Funding in progress"?
     }
+  }
+
+  @computedFrom("deal.isClaiming", "deal.isFullyClaimed")
+  private get swapCompleted() : boolean {
+    return this.deal.isClaiming && this.deal.isFullyClaimed;
   }
 }

--- a/src/funding/swap-status/swap-status.html
+++ b/src/funding/swap-status/swap-status.html
@@ -3,24 +3,18 @@
   <section class="section swap-status">
     <div class="heading heading3 title gradient">Token Swap Status</div>
     <div class="status-cards">
-      <status-card
-        dao.bind="deal.primaryDao"
-        swap-completed.bind="swapCompleted"
-        funding-failed.bind="fundingFailed"
-        tokens.bind="firstDaoTokens"
-      ></status-card>
-      <div class="swap ${swapCompleted || fundingFailed ? 'complete' : ''}">
+      <status-card dao.bind="deal.primaryDao" tokens.bind="firstDaoTokens"></status-card>
+      <!-- only display these swap icons if the deal hasn't executed swap yet -->
+      <div
+        class="swap ${swapCompleted || fundingFailed ? 'complete' : ''}"
+        if.to-view="!isExecuted"
+      >
         <i class="fas fa-arrow-right"></i>
         <i if.to-view="swapCompleted" class="fas fa-check-circle success center"></i>
         <i if.to-view="fundingFailed" class="fas fa-times-circle danger center"></i>
         <i class="fas fa-arrow-left"></i>
       </div>
-      <status-card
-        dao.bind="deal.partnerDao"
-        swap-completed.bind="swapCompleted"
-        funding-failed.bind="fundingFailed"
-        tokens.bind="secondDaoTokens"
-      ></status-card>
+      <status-card dao.bind="deal.partnerDao" tokens.bind="secondDaoTokens"></status-card>
     </div>
     <slot></slot>
   </section>

--- a/src/funding/swap-status/swap-status.html
+++ b/src/funding/swap-status/swap-status.html
@@ -13,9 +13,9 @@
         <i class="fas fa-arrow-right" if.to-view="!deal.isClaiming"></i>
         <i
           if.to-view="!deal.isClaiming && deal.isTargetReached"
-          class="fas fa-check-circle success center"
+          class="fas fa-check-circle success"
         ></i>
-        <i if.to-view="deal.isFailed" class="fas fa-times-circle danger center"></i>
+        <i if.to-view="deal.isFailed" class="fas fa-times-circle danger"></i>
         <i class="fas fa-arrow-left" if.to-view="!deal.isClaiming"></i>
       </div>
       <status-card

--- a/src/funding/swap-status/swap-status.html
+++ b/src/funding/swap-status/swap-status.html
@@ -7,6 +7,7 @@
         dao.bind="deal.primaryDao"
         swap-completed.bind="swapCompleted"
         funding-failed.bind="fundingFailed"
+        tokens.bind="firstDaoTokens"
       ></status-card>
       <div class="swap ${swapCompleted || fundingFailed ? 'complete' : ''}">
         <i class="fas fa-arrow-right"></i>
@@ -18,6 +19,7 @@
         dao.bind="deal.partnerDao"
         swap-completed.bind="swapCompleted"
         funding-failed.bind="fundingFailed"
+        tokens.bind="secondDaoTokens"
       ></status-card>
     </div>
     <slot></slot>

--- a/src/funding/swap-status/swap-status.scss
+++ b/src/funding/swap-status/swap-status.scss
@@ -13,14 +13,27 @@
     .swap {
       place-self: center;
       display: grid;
-      .center {
-        margin: 15px 0;
-      }
+      grid-gap: 15px;
       &.complete {
         color: $Border01;
       }
       .success {
         color: $Green;
+      }
+    }
+  }
+  @media screen and (max-width: $MaxContentBodyWidth) {
+    .status-cards {
+      grid-template-columns: 1fr;
+      grid-gap: 15px;
+      .swap {
+        grid-template-columns: 1fr 1fr 1fr;
+        i:first-child {
+          transform: rotate(-90deg); /* Equal to rotateZ(45deg) */
+        }
+        i:last-child {
+          transform: rotate(-90deg); /* Equal to rotateZ(45deg) */
+        }
       }
     }
   }

--- a/src/funding/swap-status/swap-status.scss
+++ b/src/funding/swap-status/swap-status.scss
@@ -21,12 +21,4 @@
       }
     }
   }
-  .execute-swap {
-    margin-top: 40px;
-    display: grid;
-    place-items: center;
-    i {
-      margin-left: 10px;
-    }
-  }
 }

--- a/src/funding/swap-status/swap-status.ts
+++ b/src/funding/swap-status/swap-status.ts
@@ -1,27 +1,20 @@
-import { ITokenFunding } from "entities/TokenFunding";
-import { DealStatus } from "entities/IDealTypes";
 import "./swap-status.scss";
 import { containerless, bindable } from "aurelia-framework";
-import { DealTokenSwap } from "../../entities/DealTokenSwap";
+import { DealTokenSwap, ITokenCalculated } from "../../entities/DealTokenSwap";
 import { Utils } from "services/utils";
 @containerless
 export class SwapStatus {
   @bindable deal: DealTokenSwap;
-  private firstDaoTokens: ITokenFunding[];
-  private secondDaoTokens: ITokenFunding[];
-  private swapCompleted: boolean;
-  private fundingFailed: boolean;
+  private firstDaoTokens: ITokenCalculated[];
+  private secondDaoTokens: ITokenCalculated[];
 
   public bind(){
     //clone the DAO's tokens from the deal so we can add contract data to the tokens
-    this.firstDaoTokens = Utils.cloneDeep(this.deal.primaryDao.tokens);
-    this.secondDaoTokens = Utils.cloneDeep(this.deal.partnerDao.tokens);
+    this.firstDaoTokens = Utils.cloneDeep(this.deal.primaryDao.tokens as ITokenCalculated[]);
+    this.secondDaoTokens = Utils.cloneDeep(this.deal.partnerDao.tokens as ITokenCalculated[]);
     //loop through each token in the primary DAO and set the contract data on those tokens
     this.firstDaoTokens.forEach(x => {this.deal.setTokenContractInfo(x, this.deal.primaryDao);});
     //loop through each token in the partner DAO and set the contract data on those tokens
     this.secondDaoTokens.forEach(x => {this.deal.setTokenContractInfo(x, this.deal.partnerDao);});
-
-    this.swapCompleted = this.deal.status === DealStatus.completed;
-    this.fundingFailed = this.deal.status === DealStatus.failed;
   }
 }

--- a/src/funding/swap-status/swap-status.ts
+++ b/src/funding/swap-status/swap-status.ts
@@ -1,14 +1,26 @@
+import { ITokenFunding } from "entities/TokenFunding";
 import { DealStatus } from "entities/IDealTypes";
 import "./swap-status.scss";
 import { containerless, bindable } from "aurelia-framework";
 import { DealTokenSwap } from "../../entities/DealTokenSwap";
-
+import { Utils } from "services/utils";
 @containerless
 export class SwapStatus {
   @bindable deal: DealTokenSwap;
+  private firstDaoTokens: ITokenFunding[];
+  private secondDaoTokens: ITokenFunding[];
   private swapCompleted: boolean;
   private fundingFailed: boolean;
+
   public bind(){
+    //clone the DAO's tokens from the deal so we can add contract data to the tokens
+    this.firstDaoTokens = Utils.cloneDeep(this.deal.primaryDao.tokens);
+    this.secondDaoTokens = Utils.cloneDeep(this.deal.partnerDao.tokens);
+    //loop through each token in the primary DAO and set the contract data on those tokens
+    this.firstDaoTokens.forEach(x => {this.deal.setTokenContractInfo(x, this.deal.primaryDao);});
+    //loop through each token in the partner DAO and set the contract data on those tokens
+    this.secondDaoTokens.forEach(x => {this.deal.setTokenContractInfo(x, this.deal.partnerDao);});
+
     this.swapCompleted = this.deal.status === DealStatus.completed;
     this.fundingFailed = this.deal.status === DealStatus.failed;
   }

--- a/src/resources/elements/address-link/address-link.html
+++ b/src/resources/elements/address-link/address-link.html
@@ -1,6 +1,10 @@
 <template>
   <div class="addressLink">
-    <a if.to-view="textClickable" ptooltip.to-view="address" click.delegate="gotoEtherscan()">
+    <a
+      if.to-view="textClickable"
+      ptooltip.to-view="address && showTooltip ? address : null"
+      click.delegate="gotoEtherscan()"
+    >
       ${linkText ? linkText : address }
       <span if.to-view="showArrowInsideLink" class="arrowIcon" />
     </a>

--- a/src/resources/elements/address-link/address-link.ts
+++ b/src/resources/elements/address-link/address-link.ts
@@ -12,6 +12,7 @@ export class AddressLink {
   @bindable linkText: string;
   @bindable textClickable = true;
   @bindable showArrowInsideLink = false;
+  @bindable showTooltip = true;
   constructor(private readonly ethereumService:EthereumService ) {
     // you can inject the element or any DI in the constructor
   }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -22,6 +22,7 @@ export function configure(config: FrameworkConfiguration): void {
     PLATFORM.moduleName("./elements/horizontal-scroller/horizontal-scroller"),
     PLATFORM.moduleName("./elements/tokenPair/tokenPair"),
     PLATFORM.moduleName("./elements/markdown/markdown"),
+    PLATFORM.moduleName("../dealDashboard/deal-swap-modal/deal-swap-modal"), //needed globally because it's being passed as a message to the ppopup-modal component
     PLATFORM.moduleName("./value-converters/number"),
     PLATFORM.moduleName("./value-converters/ethwei"),
     PLATFORM.moduleName("./value-converters/date"),


### PR DESCRIPTION
- Include token swap status component in the deal dashboard page.
- Move execute swap functionality from funding to the deal dashboard page.
- Create a <status-action-bar> component for reusability under the token status component
- Convert the ITokenFunding interface to ITokenCalculated and add properties to allow one interface to work with funding tokens as well as claiming tokens
- Add an isFullyClaimed getter to DealTokenSwap to check if a deal's tokens have been fully claimed or not
- Rewrite some logic for the PL view to handle the PL also being a representative of a DAO
- Rewrite the logic of the status card component to handle claiming tokens as well as funding tokens
- Update the swap status component to work how the SOT changed it to
- Fix a bug in the pselect component that didn't allow the value to be preselected