### PR TITLE
styles(design.input): add label margin

### DIFF
--- a/src/resources/elements/primeDesignSystem/pform-input/pform-input.scss
+++ b/src/resources/elements/primeDesignSystem/pform-input/pform-input.scss
@@ -34,6 +34,7 @@ pform-input {
     white-space: pre-line;
     line-height: 24px;
     color: $Neutral03;
+    margin-bottom: 10px;
   }
 
   .inputContainer {

--- a/src/resources/elements/primeDesignSystem/pform-input/pform-input.scss
+++ b/src/resources/elements/primeDesignSystem/pform-input/pform-input.scss
@@ -34,7 +34,6 @@ pform-input {
     white-space: pre-line;
     line-height: 24px;
     color: $Neutral03;
-    margin-bottom: 10px;
   }
 
   .inputContainer {

--- a/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.scss
+++ b/src/wizards/tokenSwapDealWizard/components/tokenDetails/tokenDetails.scss
@@ -12,6 +12,12 @@ token-details {
       margin-top: 30px;
     }
 
+    pform-input {
+      .labelDescription {
+        margin-bottom: 10px;
+      }
+    }
+
     .vesting {
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
## What was done
(quick fix, no ticket okay?)
- Mocks have bigger margin-bottom 
- fix is save, because only TokenDetails uses `label-description`

## Testing

#### Before
![image](https://user-images.githubusercontent.com/30693990/162429348-ef8c186b-9e85-4992-90b2-52b05eb19f65.png)


#### After
![image](https://user-images.githubusercontent.com/30693990/162429294-96e69390-9ac3-407a-83c0-c1f3a67707f6.png)
