### PR TITLE
515 - Deleted comment should reappear in same position on network error

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -385,7 +385,7 @@ export class DiscussionThread {
   async deleteComment(_id: string): Promise<void> {
     if (this.isLoading[`isDeleting ${_id}`]) return;
 
-    const swrComment = Utils.cloneDeep(this.threadDictionary[_id]);
+    const swrThreadComments = Utils.cloneDeep(this.threadComments);
     this.isLoading[`isDeleting ${_id}`] = true;
     delete this.threadDictionary[_id];
     this.threadComments = Object.values(this.threadDictionary);
@@ -393,15 +393,13 @@ export class DiscussionThread {
     this.discussionsService.deleteComment(this.discussionId, _id).then((isDeleted: boolean) => {
       if (!isDeleted) {
         /* If deletion did not happened, restore original comments */
-        this.threadDictionary[_id] = swrComment;
-        this.threadComments = Object.values(this.threadDictionary);
+        this.threadComments = swrThreadComments;
       } else {
         this.updateDiscussionListStatus(new Date(), this.threadComments.length);
         this.eventAggregator.publish("handleSuccess", "Comment deleted.");
       }
     }).catch (err => {
-      this.threadDictionary[_id] = swrComment;
-      this.threadComments = Object.values(this.threadDictionary);
+      this.threadComments = swrThreadComments;
       if (err.code === 4001) {
         this.eventAggregator.publish("handleFailure", "Your signature is needed in order to delete a comment");
       } else {


### PR DESCRIPTION
## What was done

## Testing
1. add two comments (note the order)
2. simulate network error disconnect wifi
3. delete comment the first comment

#### Before
4. re-appear at the at of thread

#### After
4. re-appear in correct position

https://user-images.githubusercontent.com/30693990/162587425-fd5266a2-9e8f-4641-9891-a6fd818bf3dd.mp4


