### PR TITLE
627 - Discussions observability

### DIFF
--- a/src/dealDashboard/dealClauses/dealClauses.html
+++ b/src/dealDashboard/dealClauses/dealClauses.html
@@ -3,9 +3,13 @@
     <h2 class="subtitle heading heading3">Deal Clauses</h2>
   </header>
   <ol>
+    <!-- Note the repeat.for over the length of clauses -->
+    <!-- We are encountering an issue, where removing an element from clauses (via data storage) -->
+    <!-- causes the last element in clauses to be duplicated -->
     <li
       class="clause ${authorized? 'isPrivate' : ''} ${discussionId === clause.id ? 'active' : ''}"
-      repeat.for="clause of clauses">
+      repeat.for="clauseIndex of clauses.length">
+      <let clause.bind="$this.clauses[clauseIndex]"></let>
       <span class="marker">${$index + 1}</span>
       <pre class="body">${clause.text}</pre>
       <span

--- a/src/dealDashboard/dealClauses/dealClauses.ts
+++ b/src/dealDashboard/dealClauses/dealClauses.ts
@@ -1,4 +1,4 @@
-import { autoinject, bindingMode, computedFrom } from "aurelia-framework";
+import { computedFrom, autoinject, bindingMode } from "aurelia-framework";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { DealTokenSwap } from "entities/DealTokenSwap";
 import { EthereumService } from "services/EthereumService";
@@ -12,10 +12,9 @@ export class DealClauses {
   @bindable.booleanAttr authorized = false;
   @bindable({defaultBindingMode: bindingMode.twoWay}) discussionId?: string;
 
-  @computedFrom("deal.registrationData.terms.clauses")
+  @computedFrom("deal.registrationData.terms.clauses.length")
   private get clauses(): IClause[] {
     return this.deal.registrationData.terms.clauses;
-
   }
 
   constructor(

--- a/src/dealDashboard/dealClauses/dealClauses.ts
+++ b/src/dealDashboard/dealClauses/dealClauses.ts
@@ -32,7 +32,7 @@ export class DealClauses {
    * @param id the id of the clause the discussion is for or null if it is a general discussion
    */
   private async addOrReadDiscussion(topic: string, clauseId: string | null): Promise<void> {
-    if (this.deal.clauseDiscussions[clauseId]) {
+    if (this.discussionsService.discussions[clauseId]) {
       this.discussionId = clauseId;
     } else {
       // If no discussion hash provided- create a new discussion

--- a/src/dealDashboard/dealClauses/dealClauses.ts
+++ b/src/dealDashboard/dealClauses/dealClauses.ts
@@ -1,4 +1,4 @@
-import { autoinject, bindingMode } from "aurelia-framework";
+import { autoinject, bindingMode, computedFrom } from "aurelia-framework";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { DealTokenSwap } from "entities/DealTokenSwap";
 import { EthereumService } from "services/EthereumService";
@@ -12,16 +12,16 @@ export class DealClauses {
   @bindable.booleanAttr authorized = false;
   @bindable({defaultBindingMode: bindingMode.twoWay}) discussionId?: string;
 
-  private clauses: IClause[];
+  @computedFrom("deal.registrationData.terms.clauses")
+  private get clauses(): IClause[] {
+    return this.deal.registrationData.terms.clauses;
+
+  }
 
   constructor(
     private ethereumService: EthereumService,
     private discussionsService: DiscussionsService,
   ) {
-  }
-
-  attached(): void {
-    this.clauses = this.deal.registrationData.terms.clauses;
   }
 
   /**

--- a/src/dealDashboard/dealClauses/dealClauses.ts
+++ b/src/dealDashboard/dealClauses/dealClauses.ts
@@ -32,7 +32,7 @@ export class DealClauses {
    * @param id the id of the clause the discussion is for or null if it is a general discussion
    */
   private async addOrReadDiscussion(topic: string, clauseId: string | null): Promise<void> {
-    if (this.deal.clauseDiscussions.get(clauseId)) {
+    if (this.deal.clauseDiscussions[clauseId]) {
       this.discussionId = clauseId;
     } else {
       // If no discussion hash provided- create a new discussion

--- a/src/dealDashboard/dealDashboard.html
+++ b/src/dealDashboard/dealDashboard.html
@@ -44,7 +44,7 @@
       authorized.bind="isAllowedToDiscuss"
       deal.bind="deal"
       discussion-id.two-way="discussionId"
-      if.to-view="deal.isUserRepresentativeOrLead || !deal.isPrivate"
+      show.to-view="deal.isUserRepresentativeOrLead || !deal.isPrivate"
     ></deal-clauses>
     <deal-swap-status deal.bind="deal" if.to-view="deal.fundingWasInitiated"></deal-swap-status>
     <!-- Discussions / Discussion Comments Thread -->

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -110,7 +110,7 @@ export class DiscussionThread {
       this.deal.isPrivate && this.deal.isUserRepresentativeOrLead
     ) {
       // Loads the discussion details - necessary for thread header
-      this.dealDiscussion = this.deal.clauseDiscussions.get(this.discussionId);
+      this.dealDiscussion = this.deal.clauseDiscussions[this.discussionId];
       // Ensures comment fetching and subscription
       await this.ensureDealDiscussion(this.discussionId);
       if (this.isInView(this.refThread) && !isIdChange) {

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
@@ -61,7 +61,7 @@
           </pbutton>
         </div>
       </div>
-      <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.lastModified}</time>
+      <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.createdOn | dateDiff:'float' & signal:commentCreatedOnSignal}</time>
     </header>
 
     <section class="commentBody">

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
@@ -61,7 +61,7 @@
           </pbutton>
         </div>
       </div>
-      <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.createdOn | dateDiff:'float' & signal:commentCreatedOnSignal}</time>
+      <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.createdOn | dateDiff:'float' & signal:updateTimeSignal}</time>
     </header>
 
     <section class="commentBody">

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
@@ -30,7 +30,7 @@ export class SingleComment {
     up: false,
     down: false,
   };
-  private commentCreatedOnSignal = "update-time";
+  private updateTimeSignal = "update-time";
   private commentTimeInterval: ReturnType<typeof setInterval>;
 
   constructor(
@@ -44,7 +44,7 @@ export class SingleComment {
     this.connectedAddress = this.ethereumService.defaultAccountAddress;
     this.dealClauseId = this.router.currentInstruction.params.discussionId;
     this.commentTimeInterval = setInterval((): void => {
-      this.bindingSignaler.signal(this.commentCreatedOnSignal);
+      this.bindingSignaler.signal(this.updateTimeSignal);
     }, 30000);
   }
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
@@ -1,5 +1,6 @@
 import { EthereumService } from "services/EthereumService";
 import { autoinject, bindable, computedFrom } from "aurelia-framework";
+import { BindingSignaler } from "aurelia-templating-resources";
 import { Router } from "aurelia-router";
 import { IComment, IProfile } from "entities/DealDiscussions";
 import { DateService } from "services/DateService";
@@ -29,20 +30,21 @@ export class SingleComment {
     up: false,
     down: false,
   };
+  private commentCreatedOnSignal = "update-time";
   private commentTimeInterval: ReturnType<typeof setInterval>;
 
   constructor(
     private dateService: DateService,
     private ethereumService: EthereumService,
     private router: Router,
+    private bindingSignaler: BindingSignaler,
   ) {}
 
   attached(): void {
     this.connectedAddress = this.ethereumService.defaultAccountAddress;
     this.dealClauseId = this.router.currentInstruction.params.discussionId;
-    this.comment.lastModified = this.dateService.formattedTime(parseFloat(this.comment.createdOn)).diff();
     this.commentTimeInterval = setInterval((): void => {
-      this.comment.lastModified = this.dateService.formattedTime(parseFloat(this.comment.createdOn)).diff();
+      this.bindingSignaler.signal(this.commentCreatedOnSignal);
     }, 30000);
   }
 

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -9,7 +9,7 @@
 
   <section data-test="discussions-list" class="section discussions-list">
     <!-- always when there are no discussions-->
-    <section if.bind="!discussionsArray.length">
+    <section if.bind="!discussions.size">
       <p data-test="discussions-list-instructions" class="instructions">
         <span>
           None of the clauses are currently being discussed.
@@ -29,7 +29,7 @@
       </p>
     </section>
 
-    <div class="table" if.bind="discussionsArray.length" >
+    <div class="table" if.bind="discussions.size" >
       <div class="thead">
         <span>#</span><span>Topic</span><span class="h-centered">Replies</span><span class="h-centered">Activity</span>
       </div>

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -1,4 +1,6 @@
 <template>
+ <require from='../../../resources/value-converters/dateDiff'></require>
+
   <div class="header">
     <h1 class="subtitle heading heading1 gradient" id="discussionsSection">
       Discuss
@@ -52,7 +54,7 @@
             </p>
           </div>
           <div data-test="number-of-replies" class="td h-centered v-centered">${discussion.replies || 0}</div>
-          <div class="td h-centered v-centered">${discussion.lastModified}</div>
+          <div class="td h-centered v-centered">${discussion.modifiedAt | dateDiff}</div>
         </div>
       </div>
     </div>

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -41,7 +41,7 @@
           repeat.for="[discussionId, discussion] of discussions">
           <div class="td">${findClauseIndex(discussionId) }</div>
           <div class="td">
-            <pre>${discussion.topic}</pre>
+            <pre>${deal.registrationData.terms.clauses[$index].text}</pre>
             <p class="creator">
               <i class="fas fa-pencil-alt"></i>
               <span if.bind="discussion.createdBy.name">

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -34,10 +34,10 @@
       <div class="tbody">
         <div class="tr"
           data-test="single-topic"
-          id="${discussion.id}"
-          click.delegate="navigateTo(`${discussion.id}`)"
-          repeat.for="discussion of discussionsArray">
-          <div class="td">${findClauseIndex(discussion.id) }</div>
+          id="${discussionId}"
+          click.delegate="navigateTo(`${discussionId}`)"
+          repeat.for="[discussionId, discussion] of discussions">
+          <div class="td">${findClauseIndex(discussionId) }</div>
           <div class="td">
             <pre>${discussion.topic}</pre>
             <p class="creator">

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -41,7 +41,7 @@
           repeat.for="[discussionId, discussion] of discussions">
           <div class="td">${findClauseIndex(discussionId) }</div>
           <div class="td">
-            <pre>${deal.registrationData.terms.clauses[$index].text}</pre>
+            <pre>${clauses.get(discussionId).text}</pre>
             <p class="creator">
               <i class="fas fa-pencil-alt"></i>
               <span if.bind="discussion.createdBy.name">

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -1,6 +1,4 @@
 <template>
- <require from='../../../resources/value-converters/dateDiff'></require>
-
   <div class="header">
     <h1 class="subtitle heading heading1 gradient" id="discussionsSection">
       Discuss

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -52,7 +52,7 @@
             </p>
           </div>
           <div data-test="number-of-replies" class="td h-centered v-centered">${discussion.replies || 0}</div>
-          <div class="td h-centered v-centered">${discussion.modifiedAt | dateDiff}</div>
+          <div class="td h-centered v-centered">${discussion.modifiedAt | dateDiff & signal:updateTimeSignal}</div>
         </div>
       </div>
     </div>

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -35,9 +35,16 @@ export class DiscussionsList{
     intervals: Array(typeof setInterval),
   };
 
-  @computedFrom("deal.clauseDiscussionsV2")
-  private get discussions() {
-    return new Map(Object.entries(this.deal.clauseDiscussionsV2));
+  @computedFrom("deal.clauseDiscussionsV2", "deal.registrationData.terms.clauses")
+  private get discussions(): Map<string, IDealDiscussion> {
+    const discussionsMap = new Map();
+
+    Object.entries(this.deal.clauseDiscussionsV2).forEach(([id, discussion], index) => {
+      discussion.topic = this.deal.registrationData.terms.clauses[index].text;
+      discussionsMap.set(id, discussion);
+    });
+
+    return discussionsMap;
   }
 
   private findClauseIndex(discussionId: string): string {

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -62,7 +62,13 @@ export class DiscussionsList{
 
   private findClauseIndex(discussionId: string): string {
     const discussionsIds = this.deal?.registrationData?.terms?.clauses.map(clause => clause.id);
-    return (discussionsIds.indexOf(discussionId) + 1).toString() || "-";
+    const notFoundText = "-";
+
+    if (discussionsIds.indexOf(discussionId) > -1) {
+      return (discussionsIds.indexOf(discussionId) + 1).toString() || notFoundText;
+    }
+
+    return notFoundText;
   }
 
   constructor(

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -1,5 +1,5 @@
 import { EthereumService } from "services/EthereumService";
-import { autoinject, bindingMode } from "aurelia-framework";
+import { autoinject, bindingMode, computedFrom } from "aurelia-framework";
 import { EventAggregator } from "aurelia-event-aggregator";
 import { Router } from "aurelia-router";
 
@@ -34,6 +34,11 @@ export class DiscussionsList{
   private times: any = {
     intervals: Array(typeof setInterval),
   };
+
+  @computedFrom("deal.clauseDiscussionsV2")
+  private get discussions() {
+    return new Map(Object.entries(this.deal.clauseDiscussionsV2));
+  }
 
   private findClauseIndex(discussionId: string): string {
     const discussionsIds = this.deal?.registrationData?.terms?.clauses.map(clause => clause.id);

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -39,8 +39,7 @@ export class DiscussionsList{
   private get discussions(): Map<string, IDealDiscussion> {
     const discussionsMap = new Map();
 
-    Object.entries(this.deal.clauseDiscussionsV2).forEach(([id, discussion], index) => {
-      discussion.topic = this.deal.registrationData.terms.clauses[index].text;
+    Object.entries(this.deal.clauseDiscussionsV2).forEach(([id, discussion]) => {
       discussionsMap.set(id, discussion);
     });
 

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -12,6 +12,7 @@ import { IDealDiscussion } from "entities/DealDiscussions";
 
 import "./discussionsList.scss";
 import { bindable } from "aurelia-typed-observable-plugin";
+import { IClause } from "entities/DealRegistrationTokenSwap";
 
 interface IDiscussionListItem extends IDealDiscussion {
   lastModified: string
@@ -34,6 +35,11 @@ export class DiscussionsList{
   private times: any = {
     intervals: Array(typeof setInterval),
   };
+
+  @computedFrom("deal.registrationData.terms.clauses.length")
+  private get clauses(): Map<string, IClause> {
+    return new Map<string, IClause>(this.deal.registrationData.terms.clauses.map(clause => [clause.id, clause]));
+  }
 
   @computedFrom("deal.clauseDiscussions", "deal.registrationData.terms.clauses")
   private get discussions(): Map<string, IDealDiscussion> {

--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -113,13 +113,8 @@ export class DiscussionsService {
    * @param clauseDiscussions A map of clause discussions
    * @returns void
    */
-  public loadDealDiscussions(clauseDiscussions: Map<string, IDealDiscussion>): void {
-    this.discussions = {};
-    for (const [id, discussion] of clauseDiscussions.entries()) {
-      this.discussions[id] = {
-        ...discussion,
-      };
-    }
+  public loadDealDiscussions(clauseDiscussions: Record<string, IDealDiscussion>): void {
+    this.discussions = clauseDiscussions;
   }
 
   public async setEnsName(address: string): Promise<void> {

--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -159,9 +159,8 @@ export class DiscussionsService {
         ["encrypt", "decrypt"],
       );
 
-      const discussion = {
+      const discussion: IDealDiscussion = {
         version: "0.0.1",
-        topic: args.topic,
         createdBy,
         createdAt: new Date().toISOString(),
         modifiedAt: new Date().toISOString(),

--- a/src/entities/DealDiscussions.ts
+++ b/src/entities/DealDiscussions.ts
@@ -34,17 +34,6 @@ export interface IDealDiscussion {
     address: string,
     name?: string | null;
   } | null;
-  topic: string;
   replies: number;
   key: string;
-}
-
-export class DealDiscussion implements IDealDiscussion {
-  public version: string;
-  public createdAt: string | null;
-  public modifiedAt: string | null;
-  public createdBy: {address: string, name?: string | null} | null;
-  public topic: string;
-  public replies: number;
-  public key: string;
 }

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -422,11 +422,9 @@ export class DealTokenSwap implements IDeal {
   /**
    * key is the clauseId, value is the discussion key
    */
-  public clauseDiscussions: Map<string, IDealDiscussion>;
-
-  @computedFrom("dealDocument.clauseDiscussions")
-  public get clauseDiscussionsV2(): IDealTokenSwapDocument["clauseDiscussions"] {
-    return (this.dealDocument.clauseDiscussions);
+  @computedFrom("dealDocument.clauseDiscussions.size")
+  public get clauseDiscussions(): Record<string, IDealDiscussion> {
+    return this.dealDocument.clauseDiscussions;
   }
 
   @computedFrom("registrationData.partnerDAO")
@@ -543,7 +541,6 @@ export class DealTokenSwap implements IDeal {
       this.createdAt = new Date(this.dealDocument.createdAt);
 
       await this.loadDepositContracts(); // now that we have registrationData
-      this.clauseDiscussions = this.dealDocument.clauseDiscussions ? new Map(Object.entries(this.dealDocument.clauseDiscussions)) : new Map();
 
       this.contractDealId = await this.moduleContract.metadataToDealId(formatBytes32String(this.id));
 
@@ -624,7 +621,7 @@ export class DealTokenSwap implements IDeal {
       discussionId,
       discussion,
     ).then(() => {
-      this.clauseDiscussions.set(discussionId, discussion);
+      this.clauseDiscussions[discussionId] = discussion;
     });
   }
 

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -424,7 +424,7 @@ export class DealTokenSwap implements IDeal {
    */
   @computedFrom("dealDocument.clauseDiscussions.size")
   public get clauseDiscussions(): Record<string, IDealDiscussion> {
-    return this.dealDocument.clauseDiscussions;
+    return this.dealDocument.clauseDiscussions ?? {};
   }
 
   @computedFrom("registrationData.partnerDAO")

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -422,7 +422,7 @@ export class DealTokenSwap implements IDeal {
   /**
    * key is the clauseId, value is the discussion key
    */
-  @computedFrom("dealDocument.clauseDiscussions.size")
+  @computedFrom("dealDocument.clauseDiscussions")
   public get clauseDiscussions(): Record<string, IDealDiscussion> {
     return this.dealDocument.clauseDiscussions ?? {};
   }

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -420,6 +420,11 @@ export class DealTokenSwap implements IDeal {
    */
   public clauseDiscussions: Map<string, IDealDiscussion>;
 
+  @computedFrom("dealDocument.clauseDiscussions")
+  public get clauseDiscussionsV2(): IDealTokenSwapDocument["clauseDiscussions"] {
+    return (this.dealDocument.clauseDiscussions);
+  }
+
   @computedFrom("registrationData.partnerDAO")
   public get isOpenProposal(): boolean {
     return !this.registrationData.partnerDAO;

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -115,6 +115,10 @@ export class DealTokenSwap implements IDeal {
   public totalPrice?: number;
   public initializing = true;
   public corrupt = false;
+  /**
+   * Attention: Even though, this is public, we try to minimizedirect usage.
+   * If possible try to create wrapper properties.
+   */
   public dealDocument: IDealTokenSwapDocument;
 
   /**

--- a/src/entities/IDealTypes.ts
+++ b/src/entities/IDealTypes.ts
@@ -47,6 +47,6 @@ export interface IDeal {
   initialize(): Promise<void>;
   create<TDealDocumentType extends IDealTokenSwapDocument>(doc: TDealDocumentType): IDeal;
   ensureInitialized(): Promise<void>;
-  addClauseDiscussion(clauseId: string, discussion: any): Promise<void>;
+  addClauseDiscussion(clauseId: string, discussion: IDealDiscussion): Promise<void>;
   status: DealStatus;
 }

--- a/src/entities/IDealTypes.ts
+++ b/src/entities/IDealTypes.ts
@@ -42,7 +42,7 @@ export enum DealStatus {
 export interface IDeal {
   id: string;
   corrupt: boolean;
-  clauseDiscussions: Map<string, IDealDiscussion>;
+  clauseDiscussions: Record<string, IDealDiscussion>;
   registrationData: any;
   initialize(): Promise<void>;
   create<TDealDocumentType extends IDealTokenSwapDocument>(doc: TDealDocumentType): IDeal;

--- a/src/playground/firebasePlayground/firebasePlayground.ts
+++ b/src/playground/firebasePlayground/firebasePlayground.ts
@@ -56,7 +56,6 @@ export class FirebasePlayground {
   addDealDiscussion(dealId: string, discussionId: string) {
     const discussion: IDealDiscussion = {
       version: "0.0.1",
-      topic: "Topic",
       createdBy: {
         address: "0xE834627cDE2dC8F55Fe4a26741D3e91527A8a498",
       },

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -26,6 +26,7 @@ export function configure(config: FrameworkConfiguration): void {
     PLATFORM.moduleName("./value-converters/number"),
     PLATFORM.moduleName("./value-converters/ethwei"),
     PLATFORM.moduleName("./value-converters/date"),
+    PLATFORM.moduleName("./value-converters/dateDiff"),
     PLATFORM.moduleName("./value-converters/timespan"),
     PLATFORM.moduleName("./value-converters/boolean"),
     PLATFORM.moduleName("./value-converters/secondsDays"),

--- a/src/resources/value-converters/dateDiff.ts
+++ b/src/resources/value-converters/dateDiff.ts
@@ -5,8 +5,16 @@ import { DateService } from "../../services/DateService";
 export class DateDiffValueConverter {
   constructor(private dateService: DateService) { }
 
-  public toView(dateString: string): string | null {
-    const result = this.dateService.formattedTime(new Date(dateString)).diff();
+  public toView(dateLike: string, format: "float"): string | null {
+    let input: Date | number;
+
+    if (format === "float") {
+      input = parseFloat(dateLike);
+    } else {
+      input = new Date(dateLike);
+    }
+
+    const result = this.dateService.formattedTime(input).diff();
     return result;
   }
 }

--- a/src/resources/value-converters/dateDiff.ts
+++ b/src/resources/value-converters/dateDiff.ts
@@ -1,0 +1,12 @@
+﻿import { autoinject } from "aurelia-framework";
+import { DateService } from "../../services/DateService";
+
+@autoinject
+export class DateDiffValueConverter {
+  constructor(private dateService: DateService) { }
+
+  public toView(dateString: string): string | null {
+    const result = this.dateService.formattedTime(new Date(dateString)).diff();
+    return result;
+  }
+}

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -352,13 +352,26 @@ export class FirestoreService<
    * @param discussion IDealDiscussion
    */
   public async addClauseDiscussion(dealId: string, discussionId: string, discussion: IDealDiscussion): Promise<void> {
+    /**
+     * Temporary solution: Schema for discussions is outdated (eg. has obsolete keys like `topic` or `id`).
+     * This way, we ensure only the correct props are taken.
+     */
+    const finalDiscussions: IDealDiscussion = {
+      version: discussion.version,
+      createdAt: discussion.createdAt,
+      modifiedAt: discussion.modifiedAt,
+      createdBy: discussion.createdBy,
+      replies: discussion.replies,
+      key: discussion.key,
+    };
+
     try {
       const ref = doc(firebaseDatabase, DEALS_TOKEN_SWAP_COLLECTION, dealId);
 
       await setDoc(
         ref,
         {
-          clauseDiscussions: {[discussionId]: discussion},
+          clauseDiscussions: {[discussionId]: finalDiscussions},
         },
         {merge: true},
       );


### PR DESCRIPTION
## What was done

## Testing
Setup:
- Have 2 browser open
- Choose a deal, that you can edit
- BrowserA -> deal dashboard
    - Also create a discussion (you may encounter issues (eg. Reload Discussion appears), please ignore in this PR and try to refresh the page.
- BrowserB -> edit the deal

### Case 1: Update Clause text
- BrowserB: Change a clause text, and submit changes (! remember what clause you changed)
- BrowserA
  -  -> updates the Deal Clauses section
  -  -> updates the Discussion Topic

### Case 2: Add a new Clause
- BrowserB: Add a clause, and submit changes (! remember what clause you added)
- BrowserA
  -  -> updates the Deal Clauses section with the new Clause

### Case 3: Delete a Clause
Analogue to Case 2

### Case 4: Adding a new comment
- BrowserB now navigates to the dashboard and opens a discussion
- BrowserB adds a new comment
- BrowserA
  -  -> Replies and Activity was updated

### Case 5: Deleting a comment
Analogue to Case 5

### Caes 6: Activity updates
- BrowserB: add new comment
- BrowserB: time updates (need to wait 1min)
- BrowserA: time updates (need to wait 1min)

---
---
### 
- Replies and Activity

https://user-images.githubusercontent.com/30693990/163672398-553b2788-b574-4816-aaaf-ba7238a862d9.mp4

- [x] convo down

- Deal Clause and Discussion Topic

https://user-images.githubusercontent.com/30693990/163168876-443ae357-e2ba-4bc7-a80d-18f38e901f1c.mp4


