### PR TITLE
Handle deals that were removed from observed firestore query

### DIFF
--- a/src/services/DataSourceDealsTypes.ts
+++ b/src/services/DataSourceDealsTypes.ts
@@ -4,6 +4,7 @@ import { IDealDiscussion } from "entities/DealDiscussions";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { IDealTokenSwapDocument } from "./../entities/IDealTypes";
 import { Address } from "./EthereumService";
+import { IDocumentUpdates } from "./FirestoreTypes";
 
 export type IDealIdType = string;
 
@@ -36,7 +37,7 @@ export abstract class IDataSourceDeals {
     throw new Error("Method not implemented.");
   }
 
-  getDealsObservables(accountAddress: Address, skipFirst = false): Promise<Observable<Array<IDealTokenSwapDocument>>> {
+  getDealsObservables(accountAddress: Address, skipFirst = false): Promise<Observable<IDocumentUpdates<IDealTokenSwapDocument>>> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/services/FirestoreDealsService.ts
+++ b/src/services/FirestoreDealsService.ts
@@ -5,7 +5,7 @@ import { IDataSourceDeals } from "./DataSourceDealsTypes";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { Address } from "services/EthereumService";
-import { IFirebaseDocument } from "services/FirestoreTypes";
+import { IDocumentUpdates, IFirebaseDocument } from "services/FirestoreTypes";
 import { ConsoleLogService } from "services/ConsoleLogService";
 import { Observable } from "rxjs";
 import { skip } from "rxjs/operators";
@@ -31,7 +31,7 @@ export class FirestoreDealsService<
    *
    * Note it actually returns a promise of an observable
    */
-  public async getDealsObservables(accountAddress: Address, skipFirst = false): Promise<Observable<Array<IDealTokenSwapDocument>>> {
+  public async getDealsObservables(accountAddress: Address, skipFirst = false): Promise<Observable<IDocumentUpdates<IDealTokenSwapDocument>>> {
     await this.firestoreService.ensureAuthenticationIsSynced();
 
     if (accountAddress) {

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -19,7 +19,7 @@ import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { firebaseAuth, firebaseDatabase, FirebaseService } from "./FirebaseService";
 import { combineLatest, fromEventPattern, merge, Observable, Subject } from "rxjs";
 import { map, mergeAll, skip } from "rxjs/operators";
-import { DEALS_TOKEN_SWAP_COLLECTION, IFirebaseDocument } from "./FirestoreTypes";
+import { DEALS_TOKEN_SWAP_COLLECTION, IDocumentUpdates, IFirebaseDocument } from "./FirestoreTypes";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import axios from "axios";
 import { IDealDiscussion } from "entities/DealDiscussions";
@@ -262,7 +262,7 @@ export class FirestoreService<
     return deals;
   }
 
-  public allDealsForAddressObservable(accountAddress: string, skipFirst = false): Observable<Array<IDealTokenSwapDocument>> {
+  public allDealsForAddressObservable(accountAddress: string, skipFirst = false): Observable<IDocumentUpdates<IDealTokenSwapDocument>> {
     const allPublicDeals = this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.allPublicDealsQuery()).pipe(
       skip(skipFirst ? 1 : 0),
     );
@@ -285,7 +285,7 @@ export class FirestoreService<
    *
    * @returns Observable<IFirebaseDocument<TDealDocument>[]>
    */
-  public allPublicDealsUpdatesObservable(): Observable<Array<IDealTokenSwapDocument>> {
+  public allPublicDealsUpdatesObservable(): Observable<IDocumentUpdates<IDealTokenSwapDocument>> {
     return this.getObservableOfQueryUpdates<IDealTokenSwapDocument>(this.allPublicDealsQuery());
   }
 
@@ -439,15 +439,22 @@ export class FirestoreService<
     );
   }
 
-  private getObservableOfQueryUpdates<T>(q: Query<DocumentData>): Observable<Array<T>> {
+  private getObservableOfQueryUpdates<T>(q: Query<DocumentData>): Observable<IDocumentUpdates<T>> {
     return fromEventPattern(
       (handler) => onSnapshot(
         q,
         (querySnapshot: QuerySnapshot<DocumentData>) => {
-          const updatedDocuments = [];
+          const updatedDocuments = {
+            modified: [],
+            removed: [],
+          };
           querySnapshot.docChanges().forEach((change) => {
             if (change.type === "added" || change.type === "modified") {
-              updatedDocuments.push(change.doc.data());
+              updatedDocuments.modified.push(change.doc.data());
+            }
+
+            if (change.type === "removed") {
+              updatedDocuments.removed.push(change.doc.data());
             }
           });
           handler(updatedDocuments);

--- a/src/services/FirestoreTypes.ts
+++ b/src/services/FirestoreTypes.ts
@@ -4,3 +4,8 @@ export interface IFirebaseDocument<T = any> {
   id: string;
   data: T;
 }
+
+export interface IDocumentUpdates<T> {
+  modified: Array<T>,
+  removed: Array<T>,
+}


### PR DESCRIPTION
## What was done
Handle deals removed from a query and delete them from deals map if the user is not representative/PL

## Testing

#### Before

#### After