### PR TITLE
701 - fix(discussions.thread): don't delete reply comment on abort error from theconvo

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -340,6 +340,20 @@ export class DiscussionThread {
 
   async replyComment(_id: string): Promise<void> {
     const comment = await this.discussionsService.getSingleComment(_id);
+
+    /**
+     * 1. "as any": Is typed as IComment, but the convoSdk also throws AbortController errors, so we catch it here.
+     *   TODO: better describe return type from discussionsService.
+     *
+     * 2. DOMException: theconvo sdk throws this error.
+     *   This happens, when there was no response from their endpoint within a timeout limit.
+     *   Because, there was no response, we cannot assume what happened, so just early return with error popup.
+     */
+    if ((comment as any).error instanceof DOMException) {
+      this.eventAggregator.publish("handleFailure", "An error occurred. Cannot reply to comment. Please try again later");
+      return;
+    }
+
     if (!comment._id) {
       this.eventAggregator.publish("handleFailure", `An error occurred. ${deletedByAuthorErrorMessage}`);
       this.threadComments = this.threadComments.filter(comment => comment._id !== _id);


### PR DESCRIPTION
## What was done
Handle abort error in the code (missed it)

## Testing
1. have theconvo network issues (> 6s response time) (or locally force an abortcontroller error)
2. Reply to any comment

#### Before
3. Bug: removed that comment from the UI

https://user-images.githubusercontent.com/30693990/164056794-75faf4e3-ebb1-434d-9521-7bed9ae97d4d.mp4


#### After
3. Prevents replying

https://user-images.githubusercontent.com/30693990/164056835-512adf4c-301d-4341-85eb-d18c9aac7e79.mp4


