### PR TITLE
699 - fix(discussions): obs clause text on thread view

### DIFF
--- a/src/dealDashboard/dealDiscussion/dealDiscussion.html
+++ b/src/dealDashboard/dealDiscussion/dealDiscussion.html
@@ -4,12 +4,14 @@
   <discussion-thread
     deal.bind="deal"
     authorized.bind="authorized"
+    clauses.bind="clauses"
     discussion-id.two-way="discussionId"
     if.to-view="discussionId">
   </discussion-thread>
   <discussions-list
     if.to-view="!discussionId"
     authorized.bind="authorized"
+    clauses.bind="clauses"
     deal.bind="deal"
     discussion-id.two-way="discussionId">
   </discussions-list>

--- a/src/dealDashboard/dealDiscussion/dealDiscussion.ts
+++ b/src/dealDashboard/dealDiscussion/dealDiscussion.ts
@@ -1,6 +1,7 @@
-import { autoinject, bindingMode } from "aurelia-framework";
+import { autoinject, bindingMode, computedFrom } from "aurelia-framework";
 import { bindable } from "aurelia-typed-observable-plugin";
 import { DealTokenSwap } from "entities/DealTokenSwap";
+import { IClause } from "entities/DealRegistrationTokenSwap";
 import "./dealDiscussion.scss";
 
 @autoinject
@@ -8,4 +9,9 @@ export class DealDiscussion {
   @bindable deal: DealTokenSwap;
   @bindable.booleanAttr authorized = false;
   @bindable({defaultBindingMode: bindingMode.twoWay}) discussionId?: string;
+
+  @computedFrom("deal.registrationData.terms.clauses.length")
+  private get clauses(): Map<string, IClause> {
+    return new Map<string, IClause>(this.deal.registrationData.terms.clauses.map(clause => [clause.id, clause]));
+  }
 }

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -10,7 +10,7 @@
       </div>
     </section>
     <hgroup class="title" ref="refTitle">
-      <pre><h2 data-test="thread-header" class="heading topic">${dealDiscussion.topic}</h2></pre>
+      <pre><h2 data-test="thread-header" class="heading topic">${clauses.get(discussionId).text}</h2></pre>
       <span if.bind="dealDiscussion && dealDiscussion.createdBy.address">
         <h3 class="subtext">Clause #${clauseIndex}</h3>
         <h3 class="subtext">

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -11,6 +11,7 @@ import { Utils } from "services/utils";
 
 import { IComment, IDealDiscussion, IProfile, TCommentDictionary, VoteType } from "entities/DealDiscussions";
 import { DealTokenSwap } from "entities/DealTokenSwap";
+import { IClause } from "entities/DealRegistrationTokenSwap";
 
 import "./discussionThread.scss";
 
@@ -19,6 +20,7 @@ import { ConsoleLogService } from "services/ConsoleLogService";
 
 @autoinject
 export class DiscussionThread {
+  @bindable clauses: Map<string, IClause>;
   @bindable({defaultBindingMode: bindingMode.twoWay}) discussionId?: string;
   @bindable deal: DealTokenSwap;
   @bindable authorized: boolean;

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -21,6 +21,7 @@ interface IDiscussionListItem extends IDealDiscussion {
 
 @autoinject
 export class DiscussionsList{
+  @bindable clauses: Map<string, IClause>;
   @bindable deal: DealTokenSwap;
   @bindable({defaultBindingMode: bindingMode.twoWay}) discussionId?: string;
   @bindable.booleanAttr authorized: boolean;
@@ -35,11 +36,6 @@ export class DiscussionsList{
   private hasDiscussions: boolean;
   private commentTimeInterval: ReturnType<typeof setInterval>;
   private updateTimeSignal: "update-time";
-
-  @computedFrom("deal.registrationData.terms.clauses.length")
-  private get clauses(): Map<string, IClause> {
-    return new Map<string, IClause>(this.deal.registrationData.terms.clauses.map(clause => [clause.id, clause]));
-  }
 
   @computedFrom("deal.clauseDiscussions", "deal.registrationData.terms.clauses")
   private get discussions(): Map<string, IDealDiscussion> {


### PR DESCRIPTION
## What was done
- refac to get `clauses` from the parent component.
- parent then passes into `discussionsList` and `discussionsThread` (the latter I missed in the first observability PR)

## Testing

#### Before

#### After

https://user-images.githubusercontent.com/30693990/164058056-f123e5c1-2290-4ef8-8fb0-5a8e0e750ca4.mp4

