### PR TITLE
708 - Don't re-add comment at bottom

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -421,7 +421,6 @@ export class DiscussionThread {
 
     this.threadDictionary[_id] = message;
     this.updateThreadsFromDictionary();
-    this.isLoading[`isVoting ${_id}`] = false;
   }
 
   async deleteComment(_id: string): Promise<void> {

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -393,16 +393,20 @@ export class DiscussionThread {
             this.threadComments = this.threadComments.filter(comment => comment._id !== _id);
             this.threadDictionary = this.arrayToDictionary(this.threadComments);
           }
-        }
-        else if (error.code === 4001) {
-          this.eventAggregator.publish("handleFailure", "Signature is needed in order to like/dislike a comment. ");
         } else {
-          this.eventAggregator.publish("handleFailure", "An error occurred. Like action reverted.");
+          if (error.code === 4001) {
+            this.eventAggregator.publish("handleFailure", "Signature is needed in order to like/dislike a comment. ");
+          } else {
+            this.eventAggregator.publish("handleFailure", "An error occurred. Like action reverted.");
+          }
+
+          /**
+           * In this case, no API error, so just revert the vote.
+           */
+          this.threadDictionary[_id] = swrVote;
+          this.updateThreadsFromDictionary();
         }
-
-        this.threadDictionary[_id] = swrVote;
-        this.updateThreadsFromDictionary();
-
+      }).finally(() => {
         this.isLoading[`isVoting ${_id}`] = false;
       });
 


### PR DESCRIPTION
## What was done
- Add `else` to catch the "original comment not deleted" case (This case happens, when eg. not signing)
- quickfix: related issue, where loading indicator was removed too quickly

## Note
This is almost impossible to reproduce in reality
Why impossible?
1. Deleting a comment gets streamed/websocketed, so we delete comment in any case
2. Happens in the short interval, where 2 persons perform delete, resp. vote, at the same time.

## Testing

1. AccountA deletes comment C
3. AccountB likes C



#### Before
4. B gets popup, BUT C gets re-added at bottom

https://user-images.githubusercontent.com/30693990/164077851-a5ea004b-0709-4d6f-9b35-2dcc7d96e452.mp4

#### After
3. B should get popup, and C gets removed immediately

https://user-images.githubusercontent.com/30693990/164077890-6006756d-4912-4d1f-ba32-5f923045cdf8.mp4