### PR TITLE
rearranged how DAO details are shown in the Deal Info card

### DIFF
--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -5,19 +5,18 @@
     <hr>
 
     <div class="infoSection">
-      <span
-        class="bodySmallTextBold infoTitle ${deal.primaryDao.social_medias.length >= 7 ? 'makeLabelSmaller' : undefined}">Primary DAO</span>
-      <div class="daoDetails ${deal.primaryDao.social_medias.length >= 7 ? 'moreSpaceForLinks' : undefined}">
+      <span class="bodySmallTextBold infoTitle">Primary DAO</span>
+      <div class="daoDetails">
         <img class="daoLogo" src.bind="deal.primaryDao.logoURI">
         <div class="daoTitle">
           ${deal.primaryDao.name}
-          <div class="daoSocialLinks">
-            <a href.bind="socialMedia.url" repeat.for="socialMedia of deal.primaryDao.social_medias">
-              <i class.bind="getSocialMediaDetails(socialMedia.name).icon"></i>
-            </a>
-          </div>
         </div>
       </div>
+    </div>
+    <div class="daoSocialLinks">
+      <a href.bind="socialMedia.url" repeat.for="socialMedia of deal.primaryDao.social_medias">
+        <i class.bind="getSocialMediaDetails(socialMedia.name).icon"></i>
+      </a>
     </div>
 
     <hr if.bind="partnerDao">
@@ -28,15 +27,16 @@
         <img class="daoLogo" src.bind="deal.partnerDao.logoURI">
         <div class="daoTitle">
           ${deal.partnerDao.name}
-          <div class="daoSocialLinks">
-            <a href.bind="socialMedia.url"
-              repeat.for="socialMedia of deal.partnerDao.social_medias"
-              target="_blank">
-              <i class.bind="getSocialMediaDetails(socialMedia.name).icon"></i>
-            </a>
-          </div>
         </div>
       </div>
+    </div>
+
+    <div class="daoSocialLinks" if.bind="deal.partnerDao">
+      <a href.bind="socialMedia.url"
+        repeat.for="socialMedia of deal.partnerDao.social_medias"
+        target="_blank">
+        <i class.bind="getSocialMediaDetails(socialMedia.name).icon"></i>
+      </a>
     </div>
 
     <hr>

--- a/src/dealDashboard/dealInfo/dealInfo.scss
+++ b/src/dealDashboard/dealInfo/dealInfo.scss
@@ -29,35 +29,30 @@ deal-info {
         text-overflow: ellipsis;
         overflow: hidden;
 
-        .daoSocialLinks {
-          display: flex;
-          flex-direction: row;
-          gap: 7px;
-
-          i {
-            font-size: 16px;
-            color: $Secondary05;
-          }
-        }
       }
 
     }
+
+    .daoSocialLinks {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+      gap: 7px;
+      margin-top: -10px;
+      margin-bottom: 4px;
+
+      i {
+        font-size: 16px;
+        color: $Secondary05;
+      }
+    }
+
 
     .tokenDetails {
       display: flex;
       align-items: center;
       gap: 10px;
     }
-
-    .makeLabelSmaller {
-      flex: 0;
-    }
-
-    .moreSpaceForLinks {
-      flex: 1;
-      justify-content: flex-end;
-    }
-
   }
 
   .infoSection {
@@ -74,13 +69,13 @@ deal-info {
 
     &.totalRepresentatives {
       cursor: pointer;
-      
+
       .arrow {
         justify-self: end;
         transition: all 0.2s ease-in-out;
         margin-left: 4px;
       }
-  
+
       &.active {
         .arrow {
           transform: rotate(-180deg);
@@ -93,7 +88,7 @@ deal-info {
     max-height: 0;
     overflow: hidden;
     transition: max-height 0.2s ease-out;
-    
+
     .panel-content {
       background-color: $Border01;
       border-radius: 6px;
@@ -115,8 +110,8 @@ deal-info {
           font-weight: 700;
           flex: 1;
         }
-      }  
+      }
     }
   }
-  
+
 }


### PR DESCRIPTION
## What was done
Image 1: example with simple DAO title and a few links:
![image](https://user-images.githubusercontent.com/4083652/164268526-389479b1-3179-4ee7-9741-9044615fc901.png)

Image 2: extreme example with a big DAO name an many links:
![image](https://user-images.githubusercontent.com/4083652/164268467-0e03f7c5-f2c2-4d9b-a447-0ec2fecd67e1.png)

## Testing

#### Before

#### After