### PR TITLE
723 - fix(terms): generate new ids for Make an offer wizard

### DIFF
--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
@@ -29,8 +29,9 @@ export class TermsStage implements IBaseWizardStage {
     this.stageMetadata = stageMeta.settings;
     this.stageMetadata.termsViewModes = this.stageMetadata.termsViewModes ?? this.getDefaultTermsViewModes(stageMeta.wizardType);
 
+    this.addIdsToClauses(stageMeta.wizardType);
+
     this.wizardService.registerStageValidateFunction(this.wizardManager, async () => {
-      this.addIdsToClauses();
       this.checkedForUnsavedChanges();
       const formsAreValid = await areFormsValid(this.termClauses.map(viewModel => viewModel.form));
       return formsAreValid && !this.hasUnsavedChanges;
@@ -59,9 +60,13 @@ export class TermsStage implements IBaseWizardStage {
     this.hasUnsavedChanges = this.termClauses.filter(viewModel => viewModel.viewMode === "edit").length > 0;
   }
 
-  addIdsToClauses() {
+  addIdsToClauses(wizardType: WizardType) {
     this.wizardState.registrationData.terms.clauses.forEach(clause => {
-      if (!clause.id) {
+      /**
+       * 1. !clause.id: If non, generate one.
+       * 2. `makeAnOffer`: Generate new ids, else Open Proposal and the new Partnered Deal, will have same ids.
+       */
+      if (!clause.id || wizardType === WizardType.makeAnOffer) {
         clause.id = shortUuid.generate();
       }
     });

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
@@ -29,9 +29,8 @@ export class TermsStage implements IBaseWizardStage {
     this.stageMetadata = stageMeta.settings;
     this.stageMetadata.termsViewModes = this.stageMetadata.termsViewModes ?? this.getDefaultTermsViewModes(stageMeta.wizardType);
 
-    this.addIdsToClauses(stageMeta.wizardType);
-
     this.wizardService.registerStageValidateFunction(this.wizardManager, async () => {
+      this.addIdsToClauses(stageMeta.wizardType);
       this.checkedForUnsavedChanges();
       const formsAreValid = await areFormsValid(this.termClauses.map(viewModel => viewModel.form));
       return formsAreValid && !this.hasUnsavedChanges;


### PR DESCRIPTION
## What was done
- Add another if for "Make an offer" case when generating ids

Analysis
```
Problem: Discussions of Partnered Deal are mirrored in Open Proposal and vice-versa.
Cause: clauseId of clause in Open Proposal gets copied over to Clause of Partnered Deal

Looks like, when we overlooked this use case.
- When we create a Partnered Deal, the clauseId just get copied over.
- Which then translates to same discussionsIds
- Thus discussions are mirrored

Solution: Regenerate clauseIds when creating a Partnered Deal.
Option 1: FE creates new ids in a Partnered Deal wizard
Option 2: Firebase does this
```

## Testing
1. Make an offer to an Open Proposal
2. Verify in Firestore, that `clauseId`s are different in both deals

#### Before
Clauses have same ids.
Screenshot shows Open Proposal; Note the `clauseId`
![image](https://user-images.githubusercontent.com/30693990/164297905-ad9f3bb4-6de8-4465-83a7-f7d7f38d6329.png)



#### After
Clauses have different ids
Screenshot shows Partnered Deal (created based on the above Open Proposal); Note the different `clauseId`
![image](https://user-images.githubusercontent.com/30693990/164296740-90d7cf3e-3437-4ba2-847a-ffb123750128.png)
