### PR TITLE
Fix bugs for 735

### DIFF
--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -908,7 +908,7 @@ export class DealTokenSwap implements IDeal {
   public setFundingContractInfo(token: ITokenCalculated, dao: IDAO): void {
     if (!this.isExecuted && this.daoTokenTransactions){
       //calculate only funding properties
-      token.fundingDeposited = this.daoTokenTransactions.get(dao).reduce((a, b) => b.type === "deposit" ? a.add(b.amount) : a.sub(b.amount), BigNumber.from(0));
+      token.fundingDeposited = this.daoTokenTransactions.get(dao).filter(x => x.token.address === token.address).reduce((a, b) => b.type === "deposit" ? a.add(b.amount) : a.sub(b.amount), BigNumber.from(0));
       // calculate the required amount of tokens needed to complete the swap by subtracting target from deposited
       token.fundingRequired = BigNumber.from(token.amount).sub(token.fundingDeposited);
       // calculate the percent completed based on deposited divided by target

--- a/src/funding/funding.ts
+++ b/src/funding/funding.ts
@@ -98,8 +98,6 @@ export class Funding {
         //and get the account balance for that token
         await this.setAccountBalance();
         await this.setFundingTokenAllowance();
-      } else {
-        this.selectedToken = null;
       }
     } else if (this.deal.isClaiming){
       await this.setTokenClaimingData();


### PR DESCRIPTION
Remove a check that resets the selected token.
Add a filter on the setFundingContractInfo to only look at the transactions of the token passed in.