### PR TITLE
751 - Fixed size and alignment for the copy button

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.scss
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.scss
@@ -182,6 +182,12 @@
         border-radius: $border-radius-small;
         padding: $spacing-medium-small;
         margin-bottom: $spacing-normal;
+        .copy-to-clip-button>svg {
+          display: inline-flex;
+          align-self: center;
+          width: 13.5px;
+          height: 13.5px;
+        }
       }
     }
   }


### PR DESCRIPTION
## What was done
In a comment reply, the 'copy-to-clip' icon was too large and not vertically centered with the text. 

![image](https://user-images.githubusercontent.com/2517870/165086334-eb404bfe-85d5-4633-b57e-2387376116f9.png)
