### PR TITLE
Fix e2e wallet mocking

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,9 @@ import { FirestoreService } from "services/FirestoreService";
 import { ValidationService } from "./services/ValidationService";
 
 export function configure(aurelia: Aurelia): void {
+  // Note, this Cypress hack has to be at the very start.
+  // Reason: Imports in eg. /resources/index, where EthereumService is imported to
+  //   /binding-behaviors results in EthereumService not being mocked "in time" for Cypress.
   if ((window as any).Cypress) {
     /**
      * Mock wallet connection

--- a/src/services/EthereumServiceTesting.ts
+++ b/src/services/EthereumServiceTesting.ts
@@ -175,4 +175,23 @@ export class EthereumServiceTesting {
 
     return `http://${targetedNetwork}etherscan.io/${tx ? "tx" : "address"}/${addressOrHash}`;
   }
+
+  public getEnsForAddress(address: Address): Promise<string> {
+    return this.walletProvider?.lookupAddress(address)
+      .catch(() => null);
+  }
+
+  /**
+   * Returns address that is represented by the ENS.
+   * Returns null if it can't resolve the ENS to an address
+   * Returns address if it already is an address
+   */
+  public getAddressForEns(ens: string): Promise<Address> {
+
+    /**
+     * returns the address if ens already is an address
+     */
+    return this.walletProvider?.resolveName(ens)
+      .catch(() => null); // is neither address nor ENS
+  }
 }

--- a/src/services/EthereumServiceTesting.ts
+++ b/src/services/EthereumServiceTesting.ts
@@ -154,10 +154,6 @@ export class EthereumServiceTesting {
     return false;
   }
 
-  public getEnsForAddress(_address: Address): Promise<string> {
-    return Promise.resolve("anens.eth");
-  }
-
   public lastBlock: IBlockInfo;
 
   /**


### PR DESCRIPTION
## What was done
- [fix(e2e): move mocking to very start to...](https://github.com/PrimeDAO/prime-deals-dapp/commit/273c281b2071b6075d6ba74bf1d15b1f88178b09)
... account for imports in eg. /resources/index.
A change, where EthereumService was imported to /binding-behaviors resulted
in EthService not being mocked correctly

- copy ens methods to `EthereumServiceTesting`

## Testing

#### Before

#### After