### PR TITLE
782 - Should not show empty discussions in the discussion list section

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -42,7 +42,7 @@ export class DiscussionsList{
     const discussionsMap = new Map();
 
     Object.entries(this.deal.clauseDiscussions).forEach(async ([id, discussion]) => {
-      if (!discussion) return;
+      if (!discussion || !discussion.replies) return;
 
       if (!discussion?.createdBy?.name) {
         this.discussionsService.loadProfile(discussion.createdBy.address)


### PR DESCRIPTION
## What was done
Filtering out empty discussions (Firebase ClauseDiscussion item reply count is equal to 0) from the discussions list.
