### PR TITLE
Token Swap Status: Update status automatically If Target is reached

### DIFF
--- a/src/funding/status-card/status-card.ts
+++ b/src/funding/status-card/status-card.ts
@@ -9,7 +9,6 @@ export class StatusCard {
   @bindable isPrimary: boolean;
   @bindable isDataLoaded: boolean;
 
-  @computedFrom("isDataLoaded", "deal.isFunding", "deal.isFailed", "deal.isClaiming", "deal.isFullyClaimed", "deal.isExecuted", "tokenDao.tokens")
   get chipColor(): string{
     if ((this.deal.isClaiming && this.deal.isFullyClaimed) || this.isDaoFullyClaimed()){
       return "success";
@@ -21,7 +20,6 @@ export class StatusCard {
     }
   }
 
-  @computedFrom("isDataLoaded", "deal.isFailed", "deal.isClaiming", "deal.isFullyClaimed", "deal.isExecuted", "tokenDao.tokens")
   get status(): string{
     if (this.deal.isClaiming && this.deal.isFullyClaimed){
       return "Swap completed";


### PR DESCRIPTION
Remove computedFrom tags so status card chip can update on token array change. It doesn't trigger on token array value changes if you specify the array itself.