### PR TITLE
Update firebase authentication message

### DIFF
--- a/firebaseFunctions/src/index.ts
+++ b/firebaseFunctions/src/index.ts
@@ -5,14 +5,13 @@ import * as shortUuid from "short-uuid";
 import { getAddress, verifyMessage } from "ethers/lib/utils";
 import { IDealTokenSwapDocument } from "../../src/entities/IDealTypes";
 import { generateVotingSummary, initializeVotes, initializeVotingSummary, isModifiedAtOnlyUpdate, isRegistrationDataPrivacyOnlyUpdate, isRegistrationDataUpdated, resetVotes, updateDealUpdatesCollection } from "./helpers";
-import { DEALS_TOKEN_SWAP_COLLECTION, FIREBASE_MESSAGE_TO_SIGN } from "../../src/services/FirestoreTypes";
+import { DEALS_TOKEN_SWAP_COLLECTION } from "../../src/services/FirestoreTypes";
 import { IDealRegistrationTokenSwap } from "../../src/entities/DealRegistrationTokenSwap";
 
 const admin = firebaseAdmin.initializeApp();
 export const firestore = admin.firestore();
 export const PRIMARY_DAO_VOTES_COLLECTION = "primary-dao-votes";
 export const PARTNER_DAO_VOTES_COLLECTION = "partner-dao-votes";
-const USERS_COLLECTION = "users";
 
 // Allow cross-origin requests for functions which use it
 // It is necessary to accept HTTP requests from our app,
@@ -199,55 +198,6 @@ export const createDeal = functions.https.onRequest(
 );
 
 /**
- * Creates/updates a document in the users collection,
- * which contains date when the request was made and returns it
- */
-export const getDateToSign = functions.https.onRequest(
-  (request, response) =>
-  // Allow cross-origin requests for this function
-    cors(request, response, async () => {
-      if (request.method !== "POST") {
-        return response.sendStatus(403);
-      }
-
-      if (!request.body.address) {
-        return response.sendStatus(400);
-      }
-
-      /**
-       * Address coming from the request body
-       */
-      const address: string = request.body.address;
-
-      // Fail if provided address is not an ethereum address
-      try {
-        getAddress(address);
-      } catch {
-        return response.sendStatus(500);
-      }
-
-      try {
-        /**
-         * Current date as a UTC string, later used as a part of message the user is going to sign
-         */
-        const authenticationRequestDate = new Date().toUTCString();
-
-        // Create/update document for the provided address, storing the current time, to be used to create signature
-        await admin
-          .firestore()
-          .collection(USERS_COLLECTION)
-          .doc(address)
-          .set({authenticationRequestDate});
-
-        return response.status(200).json({ authenticationRequestDate });
-      } catch (error) {
-        functions.logger.error(error);
-        return response.sendStatus(500);
-      }
-    }),
-);
-
-/**
  * Verifies that a message was signed by the provided address.
  * Therefore it proofs the ownership of the address.
  */
@@ -259,66 +209,62 @@ export const verifySignedMessageAndCreateCustomToken = functions.https.onRequest
         return response.sendStatus(403);
       }
 
-      if (!request.body.address || !request.body.signature) {
+      if (!request.body.address || !request.body.message || !request.body.signature) {
+        functions.logger.error("missing one of the required parameters");
         return response.sendStatus(400);
       }
 
       const address: string = request.body.address;
+      const message: string = request.body.message;
+      const signature: string = request.body.signature;
 
-      // Fail if provided address is not an ethereum address
+      functions.logger.info(`
+        Starting verification for the following:
+        Address: ${address},
+        Message: ${message},
+        Signature: ${signature}
+      `);
+
       try {
         getAddress(address);
       } catch {
+        functions.logger.error("Provider address is not a correct ETH address");
         return response.sendStatus(500);
       }
 
-      const signature: string = request.body.signature;
+      const signerAddress = verifyMessage(
+        message,
+        signature,
+      );
 
       try {
-        // Get the document with date when authentication process was started for this address
-        const userDocRef = admin.firestore().collection(USERS_COLLECTION).doc(address);
-        const userDoc = await userDocRef.get();
-
-        if (userDoc.exists) {
-          const authenticationRequestDate = userDoc.data()?.authenticationRequestDate;
-          const messageToSign = `${FIREBASE_MESSAGE_TO_SIGN} ${authenticationRequestDate}`;
-
-          const signerAddress = verifyMessage(
-            messageToSign,
-            signature,
-          );
-
-          // See if that matches the address the user is claiming the signature is from
-          if (signerAddress.toLowerCase() === address.toLowerCase()) {
-            // The signature was verified - reset the date to prevent replay attacks
-            // update user doc
-            await userDocRef.update({
-              authenticationRequestDate: null,
-            });
-
-            try {
-              // Create a custom token for the specified address
-              /**
-               * Firebase Token which is later going to be used to sign in to firebase from the client
-               */
-              const firebaseToken = await admin.auth().createCustomToken(address);
-
-              // Return the token
-              return response.status(200).json({ token: firebaseToken });
-            } catch (error){
-              functions.logger.error("createCustomToken error:", error);
-              return response.sendStatus(500);
-            }
-          } else {
-            // The signature could not be verified
-            return response.sendStatus(401);
-          }
-        } else {
-          return response.sendStatus(500);
-        }
-      } catch (error) {
-        functions.logger.error(error);
+        getAddress(signerAddress);
+      } catch {
+        functions.logger.error("Signer address is not a correct ETH address");
         return response.sendStatus(500);
       }
+
+      functions.logger.info("Signer address: ", signerAddress);
+
+      if (signerAddress.toLowerCase() === address.toLowerCase()) {
+        try {
+          // Create a custom token for the specified address
+          /**
+           * Firebase Token which is later going to be used to sign in to firebase from the client
+           */
+          const firebaseToken = await admin.auth().createCustomToken(address);
+
+          // Return the token
+          return response.status(200).json({ token: firebaseToken });
+        } catch (error){
+          functions.logger.error("createCustomToken error:", error);
+          return response.sendStatus(500);
+        }
+      } else {
+        // The signature could not be verified
+        functions.logger.error("Message was not signed with the claimed address");
+        return response.sendStatus(401);
+      }
+
     }),
 );

--- a/firebaseFunctions/src/index.ts
+++ b/firebaseFunctions/src/index.ts
@@ -197,6 +197,13 @@ export const createDeal = functions.https.onRequest(
     }),
 );
 
+export const getDateToSign = functions.https.onRequest(
+  () => {
+    /* this function is obsolete, must be manually deleted, when deploying to each each environment */
+    throw new Error("Method not implemented.");
+  },
+);
+
 /**
  * Verifies that a message was signed by the provided address.
  * Therefore it proofs the ownership of the address.

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,9 +55,9 @@ export class App {
       this.handleScrollEvent();
     });
 
-    this.eventAggregator.subscribe("deals.loading", async (onOff: boolean) => {
-      this.modalMessage = "Thank you for your patience while we initialize for a few moments...";
-      this.handleOnOff(onOff);
+    this.eventAggregator.subscribe("deals.loading", async (config: {onOff: boolean, message?: string}) => {
+      this.modalMessage = config.message || "Thank you for your patience while we initialize for a few moments...";
+      this.handleOnOff(config.onOff);
     });
 
     this.eventAggregator.subscribe("deal.saving", async (onOff: boolean) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -105,7 +105,12 @@ export class App {
       }
     });
 
+    this.eventAggregator.subscribe("database.account.signature.successful", () => {
+      this.modalMessage = "Thank you for your patience while we initialize for a few moments...";
+    });
+
     this.eventAggregator.subscribe("database.account.signature.cancelled", () => {
+      this.modalMessage = "Thank you for your patience while we initialize for a few moments...";
       this.alertService.showAlert({
         header: "Authentication failure",
         message: "<p>You didn't sign the authentication message. You will only see public deals and you won't be able to edit your deals.</p>",

--- a/src/services/DataSourceDealsTypes.ts
+++ b/src/services/DataSourceDealsTypes.ts
@@ -149,4 +149,11 @@ export abstract class IDataSourceDeals {
   ): Promise<void> {
     throw new Error("Method not implemented.");
   }
+
+  /**
+   * Should we ask user to sign authentication message
+   */
+  isUserSignatureRequired(accountAddress?: string): boolean {
+    throw new Error("Method not implemented.");
+  }
 }

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -157,7 +157,10 @@ export class DealService {
   public async loadDeals(): Promise<void> {
     // compute the message here - are we going to ask for the signature??
     // add that method (to figure out if we are going to request signature) to dataSourceDeals
-    const message = "Thank you for your patience while we initialize for a few moments. Check your wallet provider to ensure it is not waiting for your signature.";
+    const message = this.dataSourceDeals.isUserSignatureRequired(this.ethereumService.defaultAccountAddress) ?
+      "Check your wallet provider to ensure it is not waiting for your signature." :
+      "Thank you for your patience while we initialize for a few moments...";
+
     this.eventAggregator.publish("deals.loading", {onOff: true, message});
     await this.getDeals().finally(() => this.eventAggregator.publish("deals.loading", {onOff: false}));
     return this.observeDeals();

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -152,8 +152,9 @@ export class DealService {
   public async loadDeals(): Promise<void> {
     // compute the message here - are we going to ask for the signature??
     // add that method (to figure out if we are going to request signature) to dataSourceDeals
-    this.eventAggregator.publish("deals.loading", true);
-    await this.getDeals().finally(() => this.eventAggregator.publish("deals.loading", false));
+    const message = "Thank you for your patience while we initialize for a few moments. Check your wallet provider to ensure it is not waiting for your signature.";
+    this.eventAggregator.publish("deals.loading", {onOff: true, message});
+    await this.getDeals().finally(() => this.eventAggregator.publish("deals.loading", {onOff: false}));
     return this.observeDeals();
   }
 

--- a/src/services/FirestoreDealsService.ts
+++ b/src/services/FirestoreDealsService.ts
@@ -129,4 +129,12 @@ export class FirestoreDealsService<
 
     return this.ethereumService.defaultAccountAddress.toLowerCase() === this.firebaseService.currentFirebaseUserAddress.toLowerCase();
   }
+
+  public isUserSignatureRequired(address?: string): boolean {
+    if (!address) {
+      return false;
+    }
+
+    return !this.firebaseService.hasSignatureForAddress(address);
+  }
 }

--- a/src/services/FirestoreTypes.ts
+++ b/src/services/FirestoreTypes.ts
@@ -1,6 +1,6 @@
 export const DEALS_TOKEN_SWAP_COLLECTION = "deals-token-swap";
 export const DEALS_TOKEN_SWAP_UPDATES_COLLECTION = "deals-token-swap-updates";
-export const FIREBASE_MESSAGE_TO_SIGN = "Verify authentication attempt at";
+export const FIREBASE_MESSAGE_TO_SIGN = "Authenticate access to Prime Deals at";
 
 export interface IFirebaseDocument<T = any> {
   id: string;


### PR DESCRIPTION
## What was done
- Update authentication message
- Don't request part of the message to sign from firebase function - create message to sign (aka authentication message) entirely on the frontend
- Send message, alongside address and signature to firebase function `verifySignedMessageAndCreateCustomToken`
- Store user signatures in local storage
- Show "check metamask" message when user is required to sign

## Testing
- connect, disconnect, switch accounts

#### Before
- signature could be used only once

#### After
- signature can be reused 