### PR TITLE
812 - fix(dashboard.clauses): show button again on mobile

### DIFF
--- a/src/dealDashboard/dealClauses/dealClauses.scss
+++ b/src/dealDashboard/dealClauses/dealClauses.scss
@@ -103,10 +103,6 @@ deal-clauses {
         .body{
           width: auto;
         }
-
-        .button{
-          display: none;
-        }
       }
     }
   }


### PR DESCRIPTION
## What was done
- fix regression from #786 
  - I don't think for fixing 761 we should remove the discuss button entirely

## Testing

#### Before

#### After
Screenshots are in mobile view

Longer clause text (as wanted from original issues 761)
![image](https://user-images.githubusercontent.com/30693990/165495536-60ce761d-f1ef-4304-ac8f-6efab0ef2721.png)

Button appears again
![image](https://user-images.githubusercontent.com/30693990/165495518-f7086846-dc5f-4ab0-b61a-2aa5f4b12451.png)
