### PR TITLE
811-Token Swap Status: Images won't round (deposits table)

### DIFF
--- a/src/funding/funding.scss
+++ b/src/funding/funding.scss
@@ -214,6 +214,9 @@ $hover-transition-speed-slow: 0.4s;
                 display: grid;
                 grid-template-columns: 24px auto;
                 grid-column-gap: 11px;
+                img {
+                  border-radius: 24px;
+                }
                 span {
                   align-self: center;
                 }


### PR DESCRIPTION
## What was done
Added rounding to icons at the amount column in the funding page deposits table
