### PR TITLE
703 - Discussions: loading indicator when replying

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -107,6 +107,7 @@
           type="primary"
           full-width
           disabled.bind="isLoading.commenting || !comment.length"
+          is-loading.bind="true"
           loading.bind="isLoading.commenting"
           click.delegate="addComment()">
           ${replyToComment ? "Reply" : "Comment"}

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -107,7 +107,6 @@
           type="primary"
           full-width
           disabled.bind="isLoading.commenting || !comment.length"
-          is-loading.bind="true"
           loading.bind="isLoading.commenting"
           click.delegate="addComment()">
           ${replyToComment ? "Reply" : "Comment"}

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -18,6 +18,12 @@ import "./discussionThread.scss";
 // import { Convo } from "@theconvospace/sdk";
 import { ConsoleLogService } from "services/ConsoleLogService";
 
+export type ILoadingTracker = {
+  discussions: boolean;
+  commenting: boolean;
+  replying: boolean;
+} & Record<string, boolean>
+
 @autoinject
 export class DiscussionThread {
   @bindable clauses: Map<string, IClause>;
@@ -36,7 +42,11 @@ export class DiscussionThread {
   private threadComments: IComment[] = [];
   private threadDictionary: TCommentDictionary = {};
   private threadProfiles: Record<string, IProfile> = {};
-  private isLoading: Record<string, boolean> = {};
+  private isLoading: ILoadingTracker = {
+    discussions: false,
+    commenting: false,
+    replying: false,
+  };
   private accountAddress: Address;
   private dealDiscussion: IDealDiscussion;
   private dealDiscussionComments: IComment[];
@@ -341,7 +351,9 @@ export class DiscussionThread {
   }
 
   async replyComment(_id: string): Promise<void> {
+    this.isLoading.replying = true;
     const comment = await this.discussionsService.getSingleComment(_id);
+    this.isLoading.replying = false;
 
     /**
      * 1. "as any": Is typed as IComment, but the convoSdk also throws AbortController errors, so we catch it here.

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
@@ -36,7 +36,8 @@
           </pbutton>
           <pbutton
             type="tertiary"
-            disabled.bind="loading['isVoting ' + comment._id]"
+            disabled.bind="loading['isVoting ' + comment._id] || loading.replying"
+            is-loading.bind="loading.replying"
             click.delegate="reply()">
             ${!highlighted ? "Reply" : "Cancel"}
             &nbsp;<i class="fas fa-reply"></i>
@@ -55,7 +56,7 @@
           <pbutton type="tertiary" click.delegate="delete()">Delete</pbutton>
           <!-- Commenting out until `edit` is implemented in the convo.space -->
           <!-- <pbutton type="tertiary" disabled click.delegate="edit()">Edit</pbutton> -->
-          <pbutton type="tertiary" if.bind="!isReplying" click.delegate="reply()">
+          <pbutton type="tertiary" if.bind="!isReplying" click.delegate="reply()" disabled.bind="loading.replying" is-loading.bind="loading.replying">
             ${!highlighted ? "Reply" : "Cancel"}
             &nbsp;<i class="fas fa-reply"></i>
           </pbutton>

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.ts
@@ -5,6 +5,7 @@ import { Router } from "aurelia-router";
 import { IComment, IProfile } from "entities/DealDiscussions";
 import { DateService } from "services/DateService";
 import "./singleComment.scss";
+import { ILoadingTracker } from "../discussionThread";
 
 interface IThreadComment extends IComment {
   lastModified: string;
@@ -17,7 +18,7 @@ export class SingleComment {
   @bindable private repliesToProfile: IProfile;
   @bindable private author: string;
   @bindable private profile: IProfile;
-  @bindable private loading: Record<string, boolean>;
+  @bindable private loading: ILoadingTracker;
   @bindable private highlighted: number;
   @bindable private index: number;
   @bindable private isReply?: boolean = false;


### PR DESCRIPTION
## What was done
- add loading indicator
  - note, it will indicate loading for _all_ comments. 
  - Imo a nice feature from network perspective to block further requests
  - though might be annoying for user if loading times are long
    - imo good balance, as we are not super confident around theconvo network yet
- and disable the reply button

## Testing
reply to a comment

#### Before
no loading indicator

#### After
![image](https://user-images.githubusercontent.com/30693990/165765812-d7e2aaf0-cf80-4fd5-a8e5-ef105039f6f4.png)
