### PR TITLE
878 - styles(dashboard.menubar): align "share" to right, and mobile fixes

### DIFF
--- a/src/dealDashboard/dealMenubar/dealMenubar.html
+++ b/src/dealDashboard/dealMenubar/dealMenubar.html
@@ -10,11 +10,14 @@
     <i class="fas fa-share-alt"></i>
     SHARE
   </a>
-  <a
-    if.bind="canEdit"
-    route-href="route.bind: deal.isOpenProposal ? 'editOpenProposal' : 'editPartneredDeal' ; params.bind: { id: deal.id, stageRoute: 'proposal' }">
-    <pbutton type="secondary">Edit deal</pbutton>
-  </a>
 
-  <pbutton click.delegate="cancelDeal()" if.bind="canCancel" type="tertiary">Cancel deal</pbutton>
+  <div class="dealActionButtons" if.bind="canEdit || canCancel">
+    <a
+      if.bind="canEdit"
+      route-href="route.bind: deal.isOpenProposal ? 'editOpenProposal' : 'editPartneredDeal' ; params.bind: { id: deal.id, stageRoute: 'proposal' }">
+      <pbutton type="secondary">Edit deal</pbutton>
+    </a>
+
+    <pbutton click.delegate="cancelDeal()" if.bind="canCancel" type="tertiary">Cancel deal</pbutton>
+  </div>
 </template>

--- a/src/dealDashboard/dealMenubar/dealMenubar.scss
+++ b/src/dealDashboard/dealMenubar/dealMenubar.scss
@@ -1,19 +1,26 @@
 @import "src/resources/elements/primeDesignSystem/variables";
 
 deal-menubar {
-  display: grid;
-  grid-template-columns: auto auto auto;
-  align-items: center;
+  display: flex;
   justify-content: end;
-  grid-column-gap: 10px;
-  grid-row-gap: 20px;
 
-  i.fas {
-    font-size: 20px;
+  .dealActionButtons {
+    display: grid;
+    grid-template-columns: auto auto;
+    align-items: center;
+    justify-content: end;
+    grid-column-gap: 10px;
+    grid-row-gap: 20px;
+
+    margin-left: 30px;
   }
 
   .rateDeal {
     margin-right: 80px;
+  }
+
+  i.fas {
+    font-size: 20px;
   }
 
   .shareButton {
@@ -21,16 +28,21 @@ deal-menubar {
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    margin-right: 30px;
     gap: 10px;
   }
+}
 
+@media screen and (max-width: 700px) {
+  deal-menubar {
+    flex-direction: column;
 
-  @media screen and (max-width: 700px) {
-    grid-template-columns: auto auto;
-    justify-content: center;
+    .dealActionButtons {
+      justify-content: center;
+      margin-left: unset;
+    }
+
     .shareButton {
-      grid-column: 1/ span 2;
+      margin-bottom: 28px;
     }
   }
 }


### PR DESCRIPTION
## What was done

## Testing

#### Before

#### After
- All actions visible
1: before
2: after
![image](https://user-images.githubusercontent.com/30693990/166059504-d1930188-1bb3-4f1c-8fec-3f8696f5e5fe.png)

- Share button (case, if only button in UI)
![image](https://user-images.githubusercontent.com/30693990/166059654-b4b5052c-494e-49d3-a00e-838f4dcdac68.png)



- Mobile
![image](https://user-images.githubusercontent.com/30693990/166059460-ed335f18-d0b8-46d6-a912-1cd3b8e21480.png)
