### PR TITLE
871 - Pop-up Modals needs adjustments

### DIFF
--- a/src/resources/dialogs/dialogs.scss
+++ b/src/resources/dialogs/dialogs.scss
@@ -6,9 +6,9 @@
  * write styles against that.  See how Alert and disclaimer dialogs are created.
  */
 body > ux-dialog-overlay.active {
-  opacity: 0.5;
-  background-color: $Border01;
+  background-color: rgba(21, 6, 45, 0.5); // rgba otherwise does not work properly with blue
   backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
 }
 
 body.ux-dialog-open {

--- a/src/resources/elements/primeDesignSystem/_dialogs.scss
+++ b/src/resources/elements/primeDesignSystem/_dialogs.scss
@@ -58,6 +58,10 @@
     padding-right: 20px;
     color: $Neutral04;
     text-align: right;
+
+    .primaryFooterButton {
+      margin-left: 20px;
+    }
   }
 }
 

--- a/src/resources/elements/primeDesignSystem/_dialogs.scss
+++ b/src/resources/elements/primeDesignSystem/_dialogs.scss
@@ -53,6 +53,9 @@
   }
 
   > .dialogFooter {
+    display: flex;
+    justify-content: end;
+
     padding-top: 12px;
     padding-bottom: 12px;
     padding-right: 20px;

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -83,12 +83,13 @@ $heading: Aeonik;
   @include spin;
 }
 
-@mixin pcardBgAndGradient($backgroundColor: $BG02, $grColor01: $Primary01, $grColor02: $Secondary02) {
+@mixin pcardBgAndGradient($backgroundColor: $BG01, $grColor01: $Primary01, $grColor02: $Secondary02) {
   background: /* this is the card background: */
     linear-gradient($backgroundColor, $backgroundColor) padding-box,
       /* this is the gradient on the left side: */
     linear-gradient(to bottom, $grColor01, $grColor02) border-box;
   border-left: $border-radius-small solid transparent;
+  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.25);
 }
 
 $pPopupNotificationWidth: 336px;

--- a/src/resources/elements/primeDesignSystem/pbutton/pbutton.scss
+++ b/src/resources/elements/primeDesignSystem/pbutton/pbutton.scss
@@ -14,7 +14,7 @@
     */
   all: initial;
   outline: none;
-  padding: 14px 28px;
+  padding: 14px 24px;
   font-family: Inter;
   font-size: 16px;
   font-style: normal;
@@ -148,7 +148,7 @@ pbutton {
       @include standardButton;
 
       &:hover {
-        background-color: $Border01;
+        background-color: $Secondary05;
       }
 
       &.disabled,

--- a/src/resources/elements/primeDesignSystem/ppopup-modal/ppopup-modal.html
+++ b/src/resources/elements/primeDesignSystem/ppopup-modal/ppopup-modal.html
@@ -16,6 +16,7 @@
       >
       <pbutton
         type="primary"
+        class="primaryFooterButton"
         show.bind="showOkButton"
         ref="primaryButton"
         click.trigger="primaryClick()"


### PR DESCRIPTION

## What was done
- tweaked buttons styles (not up to date with design system)
- need rgba for background blur
- update dialog footer button margins

### Whitespace issue
There is a weird issue with whitespaces for `display: inline-block` (we had `display: block`, but whitespace was still there)
--> Suggestion is to use `display: flex`
https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace#solutions

| Before | After |
| ------ | ----- |
| unwanted `Whitespace` node with width of 4px | no gap between elements |
| ![image](https://user-images.githubusercontent.com/30693990/166235535-d26d90fe-2559-429e-b816-04fc48205dac.png)  |  ![image](https://user-images.githubusercontent.com/30693990/166235563-bdf81fba-f4cf-42bb-9cb9-6b8f0c08432e.png)|





## Testing
- Use chromium based browser
- Open a dialog (quickest one I found was on the Dasboard page -> Cancel Deal)

|          | Before | After |
| ------- | ------    | -----   |
| Buttons | ![image](https://user-images.githubusercontent.com/30693990/166234893-e8fb8056-a27a-4720-8046-3cfa661d556a.png) | ![image](https://user-images.githubusercontent.com/30693990/166234914-aacb38d6-c9f8-4fa1-8a02-40fe8926deef.png) |
| Blur | ![image](https://user-images.githubusercontent.com/30693990/166234609-b4f4a231-c111-40e6-a1e9-8d19924ebdc4.png) | ![image](https://user-images.githubusercontent.com/30693990/166234671-35b3635b-2a6f-4116-9c58-a5c1f4aabc59.png) |
