### PR TITLE
Deal Dashboard: Token Swap Status should show deposited amount of tokens while deal status is "Failed"

### DIFF
--- a/src/funding/status-card/status-card.html
+++ b/src/funding/status-card/status-card.html
@@ -18,7 +18,7 @@
             <div>
               <span class="bold">
                 <formatted-number
-                  if.to-view="deal.isFunding"
+                  if.to-view="deal.fundingWasInitiated && !deal.isClaiming"
                   thousands-separated
                   value.to-view="token.fundingDeposited | ethwei:token.decimals"
                 ></formatted-number>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2163332/166245950-a80c73a1-5290-49ea-9e3c-823c4ecb01d8.png)
