### PR TITLE
871 - Regression card background (wrong bg color)

### DIFF
--- a/src/resources/dialogs/dialogs.scss
+++ b/src/resources/dialogs/dialogs.scss
@@ -6,7 +6,8 @@
  * write styles against that.  See how Alert and disclaimer dialogs are created.
  */
 body > ux-dialog-overlay.active {
-  background-color: rgba(21, 6, 45, 0.5); // rgba otherwise does not work properly with blue
+  // Need rgba (= #15062d = $Neutral01) otherwise does not work properly with blur
+  background-color: rgba(21, 6, 45, 0.5);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }

--- a/src/resources/elements/primeDesignSystem/_dialogs.scss
+++ b/src/resources/elements/primeDesignSystem/_dialogs.scss
@@ -12,6 +12,14 @@
 
   &.pcard.gradient {
     @include pcardBgAndGradient($backgroundColor: $Border01);
+
+    /* Disabling shadow for now */
+    /* Reasons: */
+    /*   1. For the popups, box-shadow do not show up unless we add margins (see 2.) */
+    // box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.25);
+    /*   2. Apparently, one has to add a margin for the box-shadow to appear. */
+    /*     I wasn't able to have the shadow appear otherwise. */
+    // margin: 10px;
   }
 
   > .dialogHeader,

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -89,7 +89,6 @@ $heading: Aeonik;
       /* this is the gradient on the left side: */
     linear-gradient(to bottom, $grColor01, $grColor02) border-box;
   border-left: $border-radius-small solid transparent;
-  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.25);
 }
 
 $pPopupNotificationWidth: 336px;

--- a/src/resources/elements/primeDesignSystem/_variables.scss
+++ b/src/resources/elements/primeDesignSystem/_variables.scss
@@ -83,7 +83,7 @@ $heading: Aeonik;
   @include spin;
 }
 
-@mixin pcardBgAndGradient($backgroundColor: $BG01, $grColor01: $Primary01, $grColor02: $Secondary02) {
+@mixin pcardBgAndGradient($backgroundColor: $BG02, $grColor01: $Primary01, $grColor02: $Secondary02) {
   background: /* this is the card background: */
     linear-gradient($backgroundColor, $backgroundColor) padding-box,
       /* this is the gradient on the left side: */


### PR DESCRIPTION
## What was done
- revert bg color change (did not need to in the first place. I misread :(
- move shadows and disable them for now

## Testing
:warning: because in this PR, there was effectively only a color change, I did not test all instances of popups as compared to PR #897 

#### Before
![image](https://user-images.githubusercontent.com/30693990/166337602-1d265bcf-9ae0-4ac1-94d6-c0e5271f0d91.png)


#### After
![image](https://user-images.githubusercontent.com/30693990/166337608-3ca5af4a-dc80-48db-a3a2-85c211e165fe.png)
