### PR TITLE
898 - Fix e2e tests after firebase auth

### DIFF
--- a/src/services/EthereumServiceTesting.ts
+++ b/src/services/EthereumServiceTesting.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable no-console */
 import { ethers } from "ethers";
-import { BaseProvider, Web3Provider } from "@ethersproject/providers";
+import { BaseProvider, JsonRpcFetchFunc, Web3Provider } from "@ethersproject/providers";
 import { EventAggregator } from "aurelia-event-aggregator";
 import { autoinject } from "aurelia-framework";
 import { DisclaimerService } from "services/DisclaimerService";
@@ -113,10 +113,26 @@ export class EthereumServiceTesting {
   }
 
   private async setProvider(): Promise<void> {
-    // Just mock required props
-    // @ts-ignore
-    this.walletProvider = {
+    const account = localStorage.getItem("PRIME_E2E_ADDRESS");
+    const mockFetchFunc: JsonRpcFetchFunc = (method: string) => {
+      let payload;
+      switch (method) {
+        case "eth_accounts": {
+          payload = [account];
+          break;
+        }
+        default: {
+          payload = method;
+        }
+      }
+      return Promise.resolve(payload);
     };
+
+    const walletProvider = new ethers.providers.Web3Provider(mockFetchFunc);
+
+    this.walletProvider = walletProvider;
+
+    this.walletProvider.lookupAddress = () => Promise.resolve("");
 
     let address = localStorage.getItem("PRIME_E2E_ADDRESS");
     if (address === "null") {


### PR DESCRIPTION
## What was done
1. mock wallet provider (quick fix; we should explore more cleaner solutions, see ticket 488)
2. fix firebase auth by moving part of injection code further down.
  - before, some weird bundling issue I cannot explain :(

## Testing
`npm run e2e-run`

#### Before
![image](https://user-images.githubusercontent.com/30693990/166436336-39241a20-053d-4eb1-b656-c4be44f97b68.png)

#### After
! Note, the remaining fixes come from not fixing those during the last weeks.

![image](https://user-images.githubusercontent.com/30693990/166436358-e0d66a5b-19d6-4a4a-91fe-ea46d5a48abf.png)

