### PR TITLE
750 - fix(discussions.thread): add new author to profile

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -354,20 +354,21 @@ export class DiscussionThread {
   }
 
   private addAuthorToThreadProfiles(comment: IComment): void {
-    if (this.threadProfiles[comment.author]) return;
-
-    if (comment.authorENS /* author has ENS name */) {
-      this.threadProfiles[comment.author] = {
-        name: comment.authorENS,
-        address: comment.author,
-        image: "",
-      };
-    } else {
-      /* required for replies */
-      this.discussionsService.loadProfile(comment.author).then(profile => {
-        this.threadProfiles[comment.author] = profile;
-        this.isLoading[comment.author] = false;
-      });
+    if (!this.threadProfiles[comment.author]) {
+      this.isLoading[comment.author] = true;
+      if (comment.authorENS /* author has ENS name */) {
+        this.threadProfiles[comment.author] = {
+          name: comment.authorENS,
+          address: comment.author,
+          image: "",
+        };
+      } else {
+        /* required for replies */
+        this.discussionsService.loadProfile(comment.author).then(profile => {
+          this.threadProfiles[comment.author] = profile;
+          this.isLoading[comment.author] = false;
+        });
+      }
     }
   }
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -332,6 +332,7 @@ export class DiscussionThread {
 
       if (newComment) {
         this.threadComments.push({ ...newComment });
+        this.addAuthorToThreadProfiles(newComment);
 
         this.updateDiscussionListStatus(
           new Date(parseFloat(newComment.createdOn)),
@@ -349,6 +350,24 @@ export class DiscussionThread {
       this.eventAggregator.publish("handleFailure", "An error occurred while adding a comment. " + err.message);
     } finally {
       this.isLoading.commenting = false;
+    }
+  }
+
+  private addAuthorToThreadProfiles(comment: IComment): void {
+    if (this.threadProfiles[comment.author]) return;
+
+    if (comment.authorENS /* author has ENS name */) {
+      this.threadProfiles[comment.author] = {
+        name: comment.authorENS,
+        address: comment.author,
+        image: "",
+      };
+    } else {
+      /* required for replies */
+      this.discussionsService.loadProfile(comment.author).then(profile => {
+        this.threadProfiles[comment.author] = profile;
+        this.isLoading[comment.author] = false;
+      });
     }
   }
 

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -249,22 +249,7 @@ export class DiscussionThread {
 
     /* Comments author profiles */
     this.threadComments.forEach((comment: IComment) => {
-      if (!this.threadProfiles[comment.author]) {
-        this.isLoading[comment.author] = true;
-        if (comment.authorENS /* author has ENS name */) {
-          this.threadProfiles[comment.author] = {
-            name: comment.authorENS,
-            address: comment.author,
-            image: "",
-          };
-        } else {
-          /* required for replies */
-          this.discussionsService.loadProfile(comment.author).then(profile => {
-            this.threadProfiles[comment.author] = profile;
-            this.isLoading[comment.author] = false;
-          });
-        }
-      }
+      this.addAuthorToThreadProfiles(comment);
     });
 
     // Update the discussion status


### PR DESCRIPTION
## What was done
- when new address enters the conversation, we did not update the profiles map -> update it on new comment (if author not already present)

## Testing
1. Create a _new_ discussion
2. add comment
3. reply to that comment (your own comment)

#### Before
wrong avatar

#### After
https://user-images.githubusercontent.com/30693990/166440929-bd31bec3-4268-4dbe-8ef5-6647a8543421.mp4