### PR TITLE
784- Replies Column display the total amount of comments happened while deal was private.

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -185,7 +185,7 @@ export class DiscussionThread {
       };
     }
     this.updateThreadsFromDictionary();
-    this.updateDiscussionListStatus(new Date(), this.threadComments?.length || 0);
+    this.updateDiscussionListStatus(new Date());
 
     // scroll to bottom only if the user is at seeing the last message
     if (
@@ -229,7 +229,7 @@ export class DiscussionThread {
 
     if (!this.dealDiscussion) return;
 
-    this.updateDiscussionListStatus(new Date(), this.threadComments.length);
+    this.updateDiscussionListStatus(new Date());
     this.isLoading.discussions = false;
 
     // Author profile for the discussion header
@@ -268,10 +268,7 @@ export class DiscussionThread {
     });
 
     // Update the discussion status
-    this.updateDiscussionListStatus(
-      new Date(parseFloat(this.threadComments[this.threadComments.length - 1].createdOn)),
-      this.threadComments.length,
-    );
+    this.updateDiscussionListStatus(new Date(parseFloat(this.threadComments[this.threadComments.length - 1].createdOn)));
   }
 
   private isInView(element: HTMLElement): boolean {
@@ -301,15 +298,16 @@ export class DiscussionThread {
    * @param timestamp Date
    * @returns void
    */
-  private async updateDiscussionListStatus(timestamp: Date, replies: number): Promise<void> {
+  private async updateDiscussionListStatus(timestamp: Date): Promise<void> {
     if (
       (
-        this.dealDiscussion?.replies === replies &&
+        this.dealDiscussion?.replies === this.threadComments?.length &&
         new Date(this.dealDiscussion.modifiedAt).getTime() <= timestamp?.getTime()
       ) || !this.discussionId
     ) return;
 
-    this.dealDiscussion.replies = replies;
+    this.dealDiscussion.replies = this.threadComments?.length || 0;
+    this.dealDiscussion.publicReplies = this.threadComments?.filter(comment => comment.metadata.isPrivate === "false").length || 0;
     this.dealDiscussion.modifiedAt = timestamp.toISOString();
     this.threadDictionary = this.arrayToDictionary(this.threadComments);
 
@@ -333,10 +331,7 @@ export class DiscussionThread {
       if (newComment) {
         this.threadComments.push({ ...newComment });
 
-        this.updateDiscussionListStatus(
-          new Date(parseFloat(newComment.createdOn)),
-          this.threadComments.length,
-        );
+        this.updateDiscussionListStatus(new Date(parseFloat(newComment.createdOn)));
       }
       this.threadDictionary = this.arrayToDictionary(this.threadComments);
       this.comment = "";
@@ -464,7 +459,7 @@ export class DiscussionThread {
         /* If deletion did not happened, restore original comments */
         this.threadComments = swrThreadComments;
       } else {
-        this.updateDiscussionListStatus(new Date(), this.threadComments.length);
+        this.updateDiscussionListStatus(new Date());
         this.eventAggregator.publish("handleSuccess", "Comment deleted.");
       }
     }).catch (err => {

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -60,7 +60,12 @@
           </div>
           <div data-test="number-of-replies" class="td replies h-centered v-centered">
             <i class="fas fa-reply mobile only"></i>
-            ${discussion.replies || 0}
+            <span if.to-view="deal.isAuthenticatedRepresentativeOrLead">
+              ${discussion.replies || 0}
+            </span>
+            <span else>
+              ${discussion.publicReplies || 0}
+            </span>
           </div>
           <div data-test="time-since-last-activity" class="td activity h-centered v-centered">
             <i class="fas fa-bolt mobile only"></i>

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -42,7 +42,10 @@ export class DiscussionsList{
     const discussionsMap = new Map();
 
     Object.entries(this.deal.clauseDiscussions).forEach(async ([id, discussion]) => {
-      if (!discussion || !discussion.replies) return;
+      if (!discussion
+        || (!discussion.replies && this.deal.isAuthenticatedRepresentativeOrLead)
+        || (!discussion.publicReplies && !this.deal.isAuthenticatedRepresentativeOrLead)
+      ) return;
 
       if (!discussion?.createdBy?.name) {
         this.discussionsService.loadProfile(discussion.createdBy.address)

--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -172,6 +172,7 @@ export class DiscussionsService {
         createdAt: new Date().toISOString(),
         modifiedAt: new Date().toISOString(),
         replies: 0,
+        publicReplies: 0,
         key: (await window.crypto.subtle.exportKey("jwk", key)).k,
       };
 

--- a/src/entities/DealDiscussions.ts
+++ b/src/entities/DealDiscussions.ts
@@ -42,5 +42,6 @@ export interface IDealDiscussion {
     name?: string | null;
   } | null;
   replies: number;
+  publicReplies: number;
   key: string;
 }

--- a/src/playground/firebasePlayground/firebasePlayground.ts
+++ b/src/playground/firebasePlayground/firebasePlayground.ts
@@ -62,6 +62,7 @@ export class FirebasePlayground {
       createdAt: new Date().toISOString(),
       modifiedAt: new Date().toISOString(),
       replies: 0,
+      publicReplies: 0,
       key: new Date().toISOString(),
     };
     this.firestoreService.addClauseDiscussion(dealId, discussionId, discussion);

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -357,6 +357,7 @@ export class FirestoreService<
       modifiedAt: discussion.modifiedAt,
       createdBy: discussion.createdBy,
       replies: discussion.replies,
+      publicReplies: discussion.publicReplies,
       key: discussion.key,
     };
 


### PR DESCRIPTION
## What was done
Split replies count in `clauseDiscussion` into:
 - replies: total count of public and private comments
 - publicReplies: count of only public comments (metadata.isPrivate === "false")

The discussions list shows the replies count based on the deal authentication state:
If a user is authenticated as a representative/proposal lead- will show the `replies` count, otherwise the `publicReplies`.