### PR TITLE
918-Discussions list should update replies count when re connecting to a wallet

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -282,17 +282,17 @@ export class DiscussionThread {
    * @returns void
    */
   private async updateDiscussionListStatus(timestamp: Date): Promise<void> {
+    const threadSnapshot = await this.discussionsService.loadDiscussionComments(this.discussionId, this.deal, true);
     if (
       (
-        this.dealDiscussion?.replies === this.threadComments?.length &&
+        this.dealDiscussion?.replies === threadSnapshot?.length &&
         new Date(this.dealDiscussion.modifiedAt).getTime() <= timestamp?.getTime()
       ) || !this.discussionId
     ) return;
 
-    this.dealDiscussion.replies = this.threadComments?.length || 0;
-    this.dealDiscussion.publicReplies = this.threadComments?.filter(comment => comment.metadata.isPrivate === "false").length || 0;
+    this.dealDiscussion.replies = threadSnapshot.length || 0;
+    this.dealDiscussion.publicReplies = threadSnapshot?.filter(comment => comment.metadata.isPrivate === "false").length || 0;
     this.dealDiscussion.modifiedAt = timestamp.toISOString();
-    this.threadDictionary = this.arrayToDictionary(this.threadComments);
 
     this.deal.addClauseDiscussion(
       this.discussionId,

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -166,8 +166,7 @@ export class DiscussionThread {
 
     if (commentStreamMessage.name === "commentDelete") {
       if (this.threadDictionary[newComment._id]) {
-        this.threadComments = this.threadComments.filter(comment => comment._id !== newComment._id);
-        this.threadDictionary = this.arrayToDictionary(this.threadComments);
+        this.removeCommentFromThread(newComment._id);
       }
     } else {
       const key = await this.discussionsService.importKey(this.discussionId);
@@ -229,7 +228,6 @@ export class DiscussionThread {
 
     if (!this.dealDiscussion) return;
 
-    this.updateDiscussionListStatus(new Date());
     this.isLoading.discussions = false;
 
     // Author profile for the discussion header
@@ -372,8 +370,7 @@ export class DiscussionThread {
 
     if (!comment._id) {
       this.eventAggregator.publish("handleFailure", `An error occurred. ${deletedByAuthorErrorMessage}`);
-      this.threadComments = this.threadComments.filter(comment => comment._id !== _id);
-      this.threadDictionary = this.arrayToDictionary(this.threadComments);
+      this.removeCommentFromThread(_id);
       return;
     }
 
@@ -406,8 +403,7 @@ export class DiscussionThread {
              * Only revert vote action, when api error occured.
              * In this case, it was very likely, that the comment was deleted by the original author (note error code 404)
              */
-            this.threadComments = this.threadComments.filter(comment => comment._id !== _id);
-            this.threadDictionary = this.arrayToDictionary(this.threadComments);
+            this.removeCommentFromThread(_id);
           }
         } else {
           if (error.code === 4001) {

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.html
@@ -60,7 +60,7 @@
           </div>
           <div data-test="number-of-replies" class="td replies h-centered v-centered">
             <i class="fas fa-reply mobile only"></i>
-            <span if.to-view="deal.isAuthenticatedRepresentativeOrLead">
+            <span if.to-view="authorized">
               ${discussion.replies || 0}
             </span>
             <span else>

--- a/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
+++ b/src/dealDashboard/dealDiscussion/discussionsList/discussionsList.ts
@@ -43,8 +43,8 @@ export class DiscussionsList{
 
     Object.entries(this.deal.clauseDiscussions).forEach(async ([id, discussion]) => {
       if (!discussion
-        || (!discussion.replies && this.deal.isAuthenticatedRepresentativeOrLead)
-        || (!discussion.publicReplies && !this.deal.isAuthenticatedRepresentativeOrLead)
+        || (!discussion.replies && this.authorized)
+        || (!discussion.publicReplies && !this.authorized)
       ) return;
 
       if (!discussion?.createdBy?.name) {


### PR DESCRIPTION
## What was done
1. Simplify the filter to use deal.isAuthenticated…
2. Add a ‘snapshot’ flag to return an unfiltered comment array (and also not decrypted) - used to update the correct count. 
3. Updating the discussion list to use ‘authorized’ bindable.
4. Some cleanup
