### PR TITLE
892- Discussions: Improve loading indicator for single comments

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -22,8 +22,8 @@ import { ConsoleLogService } from "services/ConsoleLogService";
 export type ILoadingTracker = {
   discussions: boolean;
   commenting: boolean;
-  replying: boolean;
-} & Record<string, boolean>
+  replying: Record<string, boolean>;
+} & Record<string, boolean | Record<string, boolean>>
 
 @autoinject
 export class DiscussionThread {
@@ -46,7 +46,7 @@ export class DiscussionThread {
   private isLoading: ILoadingTracker = {
     discussions: false,
     commenting: false,
-    replying: false,
+    replying: {},
   };
   private accountAddress: Address;
   private dealDiscussion: IDealDiscussion;
@@ -353,9 +353,9 @@ export class DiscussionThread {
   }
 
   async replyComment(_id: string): Promise<void> {
-    this.isLoading.replying = true;
+    this.isLoading.replying[_id] = true;
     const comment = await this.discussionsService.getSingleComment(_id);
-    this.isLoading.replying = false;
+    this.isLoading.replying[_id] = false;
 
     /**
      * 1. "as any": Is typed as IComment, but the convoSdk also throws AbortController errors, so we catch it here.

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
@@ -36,8 +36,8 @@
           </pbutton>
           <pbutton
             type="tertiary"
-            disabled.bind="loading['isVoting ' + comment._id] || loading.replying"
-            is-loading.bind="loading.replying"
+            disabled.bind="loading['isVoting ' + comment._id] || loading.replying[comment._id]"
+            is-loading.bind="loading.replying[comment._id]"
             click.delegate="reply()">
             ${!highlighted ? "Reply" : "Cancel"}
             &nbsp;<i class="fas fa-reply"></i>
@@ -56,13 +56,16 @@
           <pbutton type="tertiary" click.delegate="delete()">Delete</pbutton>
           <!-- Commenting out until `edit` is implemented in the convo.space -->
           <!-- <pbutton type="tertiary" disabled click.delegate="edit()">Edit</pbutton> -->
-          <pbutton type="tertiary" if.bind="!isReplying" click.delegate="reply()" disabled.bind="loading.replying" is-loading.bind="loading.replying">
+          <pbutton type="tertiary" if.bind="!isReplying" click.delegate="reply()" disabled.bind="loading.replying[comment._id]">
             ${!highlighted ? "Reply" : "Cancel"}
             &nbsp;<i class="fas fa-reply"></i>
           </pbutton>
         </div>
       </div>
       <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.createdOn | dateDiff:'float' & signal:updateTimeSignal}</time>
+      <div if.bind="loading.replying[comment._id]" class="replying">
+        <i class="spinner fas fa-circle-notch fa-spin"></i>
+      </div>
     </header>
 
     <section class="commentBody">


### PR DESCRIPTION
## What was done
- [X] Spinner is showing also while not hovering over a comment
- [X] Spinner shows only for the relevant comment.

### Before
Spinner was shown only while hovering a comment (all comments in the thread)

### After
![reply loading spinner](https://user-images.githubusercontent.com/2517870/166707234-9860a210-2f25-435c-a7f1-ff91b214ecac.gif)

