### PR TITLE
933-Discussions: Improve loading indicator for single comments - Like/Dislike

### DIFF
--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.ts
@@ -22,6 +22,7 @@ import { ConsoleLogService } from "services/ConsoleLogService";
 export type ILoadingTracker = {
   discussions: boolean;
   commenting: boolean;
+  voting: Record<string, boolean>;
   replying: Record<string, boolean>;
 } & Record<string, boolean | Record<string, boolean>>
 
@@ -46,6 +47,7 @@ export class DiscussionThread {
   private isLoading: ILoadingTracker = {
     discussions: false,
     commenting: false,
+    voting: {},
     replying: {},
   };
   private accountAddress: Address;
@@ -391,8 +393,8 @@ export class DiscussionThread {
     const typeInverse = types[types.length - types.indexOf(type.toString()) - 1];
     const currentWalletAddress = this.ethereumService.defaultAccountAddress;
 
-    if (this.isLoading[`isVoting ${_id}`]) return;
-    this.isLoading[`isVoting ${_id}`] = true;
+    if (this.isLoading.voting[_id]) return;
+    this.isLoading.voting[_id] = true;
 
     const swrVote = Utils.cloneDeep(this.threadDictionary[_id]);
 
@@ -423,7 +425,7 @@ export class DiscussionThread {
           this.updateThreadsFromDictionary();
         }
       }).finally(() => {
-        this.isLoading[`isVoting ${_id}`] = false;
+        this.isLoading.voting[_id] = false;
       });
 
     /* Toggle vote locally */

--- a/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/singleComment/singleComment.html
@@ -23,33 +23,31 @@
       <div class="actions">
         <div if.bind="comment.author !== connectedAddress && isAuthorized" data-test="single-comment-action" class="vote action">
           <pbutton type="tertiary"
-            is-loading.bind="loading['isVoting ' + comment._id] && pressed.up"
-            disabled.bind="loading['isVoting ' + comment._id]"
+            disabled.bind="loading.voting[comment._id]"
             click.delegate="vote('toggleUpvote')">
             <i data-test="like-button" class="fas fa-thumbs-up ${isThumbUp}"></i>
           </pbutton>
           <pbutton type="tertiary"
-            is-loading.bind="loading['isVoting ' + comment._id] && pressed.down"
-            disabled.bind="loading['isVoting ' + comment._id]"
+            disabled.bind="loading.voting[comment._id]"
             click.delegate="vote('toggleDownvote')">
             <i data-test="dislike-button" class="fas fa-thumbs-down ${isThumbDown}"></i>
           </pbutton>
           <pbutton
             type="tertiary"
-            disabled.bind="loading['isVoting ' + comment._id] || loading.replying[comment._id]"
+            disabled.bind="loading.voting[comment._id] || loading.replying[comment._id]"
             click.delegate="reply()">
             ${!highlighted ? "Reply" : "Cancel"}
             &nbsp;<i class="fas fa-reply"></i>
           </pbutton>
         </div>
-        <div if.bind="!loading['isVoting ' + comment._id]" class="vote count ${isAuthorized ? 'isAuthorized' : ''}">
+        <div if.bind="!loading.voting[comment._id]" class="vote count ${isAuthorized ? 'isAuthorized' : ''}">
           <div class="${voteDirection}Vote">
             <i class="fas fa-thumbs-${voteDirection === 'no'? 'up':voteDirection}"></i>
             ${voteDirection === 'down' ? -votes : votes}
           </div>
         </div>
         <div else class="vote count ${isAuthorized ? 'isAuthorized' : ''}">
-          <div type="tertiary"><i class="fas fa-thumbs-up"></i> <i class="spinner fas fa-circle-notch fa-spin"></i></div>
+          <div type="tertiary"><i class="fas fa-thumbs-up"></i></div>
         </div>
         <div if.bind="comment.author === connectedAddress && isAuthorized" data-test="single-comment-action" class="vote action">
           <pbutton type="tertiary" click.delegate="delete()">Delete</pbutton>
@@ -62,7 +60,7 @@
         </div>
       </div>
       <time class="lastActivity ${isAuthorized ? 'isAuthorized' : ''}">${comment.createdOn | dateDiff:'float' & signal:updateTimeSignal}</time>
-      <div if.bind="loading.replying[comment._id]" class="replying">
+      <div if.bind="loading.replying[comment._id] || loading.voting[comment._id]" class="replying">
         <i class="spinner fas fa-circle-notch fa-spin"></i>
       </div>
     </header>


### PR DESCRIPTION
## What was done
Fix comment 'like/dislike' button spinner to be consistent with the 'reply' button spinner and show both on hover and while the mouse is away.

![like-dislike-spinner](https://user-images.githubusercontent.com/2517870/166818880-b96598a1-8098-4d58-98f0-827f8d0182af.gif)

