### PR TITLE
Remove auto gen titles in the docs 

### DIFF
--- a/src/documentation/baseDocument.html
+++ b/src/documentation/baseDocument.html
@@ -1,6 +1,5 @@
 <template>
   <div class="documentBodyContainer animated-page au-animate">
-    <div class="title heading heading3">${title}</div>
     <div class="documentBody">
       <markdown document.to-view="content"></markdown>
     </div>

--- a/src/documentation/officialDocs/TermsOfService.md
+++ b/src/documentation/officialDocs/TermsOfService.md
@@ -1,14 +1,13 @@
-**Terms & Conditions**
+# Terms & Conditions #
 
-Please read these Terms carefully before participating on our launch platform. These Terms tell you who we are, what we offer, what to do if there is a problem, and other important information. If you think that there is a mistake in these Terms, please contact us to discuss at forum.prime.xyz
+Please read these Terms carefully before participating on the Prime Deals platform. These Terms tell you who we are, what we offer, what to do if there is a problem, and other important information. If you think that there is a mistake in these Terms, please contact us to `discuss` at `forum.prime.xyz`
 
-**WHO WE ARE AND HOW TO CONTACT US**
+## WHO WE ARE AND HOW TO CONTACT US
+1.1. Prime Deals is operated by PrimeDAO ("We"). We are an Ethereum based organization managed by community members. To contact us, please write to us via the Prime Deals subcategory of forum.prime.xyz
 
-1.1. Prime Launch is operated by PrimeDAO ("We"). We are an Ethereum based organisation managed by community members. To contact us, please write to us via the Prime Launch subcategory of forum.prime.xyz
+1.2. We use open source products and developer materials from Prime Development Foundation, and affiliated (legal) persons ("Affiliates"), as well as from other third parties to provide a platform (the "Platform") to interact with different protocols, such as the Balancer Protocol (together: the "Protocol"). The Platform is autonomous and acts independently from the providers of Protocol.
 
-1.2. We use open source products and developer materials from Balancer Labs, Prime Development Foundation and affiliated (legal) persons ("Affiliates"), as well as from other third parties to provide a platform (the "Platform") to interact with different protocols, such as the Balancer Protocol (together: the "Protocol"). The Platform is autonomous, and acts independently from the providers of Protocol.
-
-**WE PROVIDE A PLATFORM TO INTERACT WITH THIRD PARTY PROTOCOLS**
+## **WE PROVIDE A PLATFORM TO INTERACT WITH THIRD PARTY PROTOCOLS**
 
 2.1. The Platform is a graphical user interface that facilitates interacting with different Protocols for ERC20 tokens. 
 
@@ -16,7 +15,7 @@ Please read these Terms carefully before participating on our launch platform. T
 
 2.3. We are not a custodian, nor a counterparty to any transactions executed by you on the Protocol and the Platform. We do not provide any order matching, guaranteed prices, or similar exchange or trading platform services. 
 
-**BY USING OUR PLATFORM, YOU ACCEPT THESE TERMS**
+## **BY USING OUR PLATFORM, YOU ACCEPT THESE TERMS**
 
 3.1. These general terms and conditions ("Terms") apply to the use of our Platform.
 
@@ -28,29 +27,29 @@ Please read these Terms carefully before participating on our launch platform. T
 
 3.5. We may terminate or suspend your access to our Platform immediately, without prior notice or liability, if you breach any clause of the Terms. Upon termination of your access, your right to use the Platform will immediately cease. Clauses 7 through 20 survive termination of these Terms.
 
-3.6. You may have been referred to the Platform by a third party. We are not liable for any agreement or terms that may exist between you and such third party.
+3.6. You may have been referred to the Platform by a third party. We are not liable for any agreement or terms that may exist between you and such a third party.
 
-**WHAT YOU NEED TO USE OUR PLATFORM**
+## **WHAT YOU NEED TO USE OUR PLATFORM**
 
-4.1. A detailed step-by-step guide on how to use the Platform can be found in the "Prime Launch Documentation - ADD LINK" section on the Platform.
+4.1. A detailed step-by-step guide on how to use the Platform can be found in the "Prime Deals Documentation - https://www.prime.xyz/deals/docs" section on the Platform.
 
 4.2	To use the Platform, you need:
 
 4.2.1. A wallet compatible with the Ethereum Blockchain or Ethereum Virtual Machine compatible validation mechanisms. We currently only support MetaMask, Torus and WalletConnect compatible wallets. We have not tested compatibility with any other wallets.
 
-4.2.2. An ERC 20 token for participation in a launch. 
+4.2.2. An ERC 20 token for participation in a deal. 
 
-4.2.3. Depending on whether you interact with Prime Launch on Ethereum Mainnet or Ethereum Virtual Machine compatible validation mechanisms, sufficient ETH must be in your Wallet to pay for transactions fees, which are incurred through the Protocol and on the Blockchain.
+4.2.3. Depending on whether you interact with Prime Deals on Ethereum Mainnet or Ethereum Virtual Machine compatible validation mechanisms, sufficient ETH must be in your Wallet to pay for transactions fees, which are incurred through the Protocol and on the Blockchain.
 
-**FEES LEVIED BY US**
+## **FEES LEVIED BY US**
 
-5.1. We do not currently levy any fees on users who participate in a launch on Prime Launch.
+5.1. We do not currently levy any fees on users who participate in a deal on Prime Deals.
 
 5.2. The Protocol might require a contribution of any kind, if so described.
 
 5.3. Users interacting with the Ethereum Mainnet or Ethereum Virtual Machine compatible validation mechanisms will incur transaction costs. Transaction costs are independent of the Platform and go to miners processing the transaction on the networks. We have no control over and do not set the transaction costs, nor do we benefit from these. The Platform does not change the default suggestion of your wallet provider. Users may be able to change the default transaction fee within their wallet, depending on the wallet used.
 
-**YOUR CRYPTOGRAPHIC ASSETS**
+## **YOUR CRYPTOGRAPHIC ASSETS**
 
 6.1. You must own and fully control the wallet you use in connection with our Platform.
 
@@ -58,29 +57,29 @@ Please read these Terms carefully before participating on our launch platform. T
 
 6.3. We are not responsible for any security measures relating to the wallet you use for the Platform and exclude (to the fullest extent permitted under applicable law) any and all liability for any security breaches or other acts or omissions, which result in your loss of access or custody of any cryptographic assets stored thereon.
 
-**YOUR TAX LIABILITIES**
+## **YOUR TAX LIABILITIES**
 
 7.1. You are solely responsible to determine if your use of the Platform has tax implications for you. You agree not to hold us liable for any tax liability associated with or arising from the operation of the Platform or any other action or transaction related thereto.
 
-**INFORMATION ON THE PLATFORM IS NOT ADVICE**
+## **INFORMATION ON THE PLATFORM IS NOT ADVICE**
 
 8.1. None of the information available on our Platform, or made otherwise available to you in relation to its use, constitutes any legal, tax, financial or other advice. When in doubt as to the action you should take, you should consult your legal, financial, tax or other professional advisors.
 
-**OUR INTELLECTUAL PROPERTY RIGHTS**
+## **OUR INTELLECTUAL PROPERTY RIGHTS**
 
 9.1. Subject to the application of the GNU Lesser General Public License v3.0 to the software code of the Platform, we are the owner or the licensee of all intellectual property rights of the Platform. Those works are protected by intellectual property laws and treaties around the world. All such rights are reserved.
 
-9.2. Subject to your compliance with these Terms, we grant you a limited, revocable, non-exclusive, non-transferable, non-sublicensable licence to access the Platform. This licence does not include any resale, commercial or derivative use of our Platform. We reserve and retain all rights not expressly granted to you in these Terms. The Platform may not be reproduced, sold, or otherwise exploited for any commercial purpose without our express prior written consent. You may not frame or utilize framing techniques to enclose any trademark, logo, or other proprietary information of us without our express prior written consent. You may not misuse the Platform and may only use it as permitted by law. If you breach our intellectual property rights in violation of these Terms, your license to use our Platform will automatically be revoked and terminated immediately.
+9.2. Subject to your compliance with these Terms, we grant you a limited, revocable, non-exclusive, non-transferable, non-sublicensable license to access the Platform. This license does not include any resale, commercial or derivative use of our Platform. We reserve and retain all rights not expressly granted to you in these Terms. The Platform may not be reproduced, sold, or otherwise exploited for any commercial purpose without our express prior written consent. You may not frame or utilize framing techniques to enclose any trademark, logo, or other proprietary information of us without our express prior written consent. You may not misuse the Platform and may only use it as permitted by law. If you breach our intellectual property rights in violation of these Terms, your license to use our Platform will automatically be revoked and terminated immediately.
 
-**WE ARE NOT RESPONSIBLE FOR BUGS AND YOU MUST NOT INTRODUCE THEM**
+## **WE ARE NOT RESPONSIBLE FOR BUGS AND YOU MUST NOT INTRODUCE THEM**
 
 10.1. We do not guarantee that our Platform will be secure or free from bugs or viruses.
 
 10.2. You are responsible for configuring your information technology and computer programmes to access our Platform. You should use your own virus protection software.
 
-10.3. You must not misuse our Platform by knowingly introducing material that is malicious or technologically harmful. You must not attempt to gain unauthorised access to our Platform, any server on which our Platform may be stored, computer or database connected to our Platform. You must not attack our Platform via a denial-of-service attack or a distributed denial-of service attack. By breaching this provision, you would commit a criminal offence. We will report any such breach to the relevant law enforcement authorities and we will cooperate with those authorities, including, where possible, by disclosing your identity to them. In the event of such a breach, your right to use our Platform will cease immediately.
+10.3. You must not misuse our Platform by knowingly introducing material that is malicious or technologically harmful. You must not attempt to gain unauthorised access to our Platform, any server on which our Platform may be stored, computer or database connected to our Platform. You must not attack our Platform via a denial-of-service attack or a distributed denial-of service attack. By breaching this provision, you would commit a criminal offense. We will report any such breach to the relevant law enforcement authorities and we will cooperate with those authorities, including, where possible, by disclosing your identity to them. In the event of such a breach, your right to use our Platform will cease immediately.
 
-**RULES ABOUT YOU LINKING TO OUR PLATFORM**
+## **RULES ABOUT YOU LINKING TO OUR PLATFORM**
 
 11.1. You may link to our Platform, provided you do so in a way that is fair and legal and does not damage our reputation or take advantage of it. You must not establish a link in such a way as to suggest any form of association, approval or endorsement on our part where none exists. You must not establish a link to our Platform in any website without the website’s authorization.
 
@@ -88,7 +87,7 @@ Please read these Terms carefully before participating on our launch platform. T
 
 11.3. The website in which you are linking must comply in all respects with the content standards set out in these Terms. If you wish to link to or make any use of content on our interface other than that set out above, please contact us at forum.prime.xyz
 
-**YOUR WARRANTIES AND REPRESENTATIONS TO US**
+## **YOUR WARRANTIES AND REPRESENTATIONS TO US**
 
 12.1. By using our Platform you hereby agree, represent and warrant that:
 
@@ -120,7 +119,7 @@ Please read these Terms carefully before participating on our launch platform. T
 
 12.1.14. the risks of using the Platform are substantial and include, but are not limited to the ones set out in the APPENDIX, which is hereby expressly incorporated into these Terms, and you are willing to accept the risk of loss associated therewith.
 
-**YOUR INDEMNIFICATION AND LIABILITY TO US**
+## **YOUR INDEMNIFICATION AND LIABILITY TO US**
 
 13.1. You agree to release and indemnify, defend and hold us and any of our Affiliates harmless, as well as any directors, officers, employees, contractors, shareholders and representatives of any of the foregoing, from and against any and all losses, liabilities, damages, costs claims or actions of any kind arising or resulting from your use of our Platform, your breach of these Terms, and any of your acts or omissions that infringe the rights of any person.
 
@@ -128,7 +127,7 @@ Please read these Terms carefully before participating on our launch platform. T
 
 13.3. The indemnity set out here is in addition to, and not in lieu of, any other remedies that may be available to us under applicable law.
 
-**OUR LIABILITY FOR LOSS SUFFERED BY YOU IS LIMITED**
+## **OUR LIABILITY FOR LOSS SUFFERED BY YOU IS LIMITED**
 
 14.1. We do not exclude or limit our liability to you where it would be unlawful to do so. This includes liability for death or personal injury caused by our negligence or fraud. 
 
@@ -140,59 +139,55 @@ We exclude all implied conditions, warranties, representations or other terms th
 14.3. IF YOU ARE A CONSUMER USER: 
 Please note that we only provide our platform for domestic and private use. You agree not to use our platform for any commercial or business purposes, and we have no liability to you for any loss of profit, loss of business, business interruption, or loss of business opportunity. Only if our platform damages a device or digital content belonging to you and this is caused by our failure to use reasonable care and skill, we will pay you compensation. Such compensation shall be limited to the amount of fees paid by you to us for using our platform. At this point in time, our services are free of charge and accordingly no compensation will be payable to you. Moreover, we will not be liable for damage that you could have avoided by following our advice or for damage that was caused by you failing to correctly follow our instructions or to have in place the minimum system requirements advised by us.
 
-**HOW TO RESOLVE COMPLAINTS AND DISPUTES**
+## **HOW TO RESOLVE COMPLAINTS AND DISPUTES**
 
-15.1. If an alleged breach, controversy, claim, dispute or difference arises out of or in connection with the present Terms between you and us (a "Dispute"), you agree to seek to resolve the matter with us amicably by referring the matter first to Prime Launch subcategory of forum.prime.xyz, with a detailed description, the date and time the issue arose, your handle to contact you on and the outcome you are seeking.
+15.1. If an alleged breach, controversy, claim, dispute or difference arises out of or in connection with the present Terms between you and us (a "Dispute"), you agree to seek to resolve the matter with us amicably by referring the matter first to Prime Deals subcategory of forum.prime.xyz, with a detailed description, the date and time the issue arose, your handle to contact you on and the outcome you are seeking.
 
 15.2. In the event a Dispute cannot be resolved amicably in accordance with clause 15.1, you must first refer the Dispute to proceedings under the International Chamber of Commerce ("ICC") Mediation Rules, which Rules are deemed to be incorporated by reference into this clause 15. The place of mediation shall be Willemstad, Curaçao. The language of the mediation proceedings shall be English.
 
 15.3. If the Dispute has not been settled pursuant to the ICC Mediation Rules within 40 days following the filing of a Request for Mediation in accordance with the ICC Mediation Rules or within such other period as the parties to the dispute may agree in writing, such Dispute shall thereafter be finally settled by the Court of Justice of Curaçao, that shall have exclusive jurisdiction.
 
-**GOVERNING LAW**
+## **GOVERNING LAW**
 
 16.1. This Agreement shall be governed by and construed in accordance with the substantive laws of Curaçao.
 
-**THIRD PARTY BENEFICIARIES**
+## **THIRD PARTY BENEFICIARIES**
 
-17.1. These Terms also apply to the benefit of Affiliates and also encompasses Protocol related matters in this context.
+17.1. These Terms also apply to the benefit of Affiliates and also encompasses Protocol-related matters in this context.
 
 17.2. Subject to clause 17.1, these terms do not give rise to any third-party rights, which may be enforced against us.
 
-**ENTIRE AGREEMENT AND ASSIGNMENT**
+## **ENTIRE AGREEMENT AND ASSIGNMENT**
 
 18.1. We may assign these Terms to any Affiliate or in connection with a merger or other disposition of all or substantially all of our assets.
 
 18.2. These Terms constitute the entire and exclusive agreement between us and you regarding its subject matter, and supersede and replace any previous or contemporaneous written or oral contract, promises, assurances, assurances, warranty, representation or understanding regarding its subject matter, whether written or oral. You shall have no claim for innocent or negligent misrepresentation or misstatement based on any statement in these Terms, though nothing in this clause shall limit or exclude any liability for fraud.
 
-**NO WAIVURE OF RIGHTS AND NO ASSIGNMENT**
+## **NO WAIVURE OF RIGHTS AND NO ASSIGNMENT**
 
 19.1. You may not assign, transfer or delegate any of your rights or duties arising out of or in connection with these Terms to a third party. Any such assignment or transfer shall be void and shall not impose any obligation or liability on us to the assignee or transferee.
 
 19.2. Any delay or omission by us in relation to the exercise of any right granted by law or under these Terms shall not as a result exclude or prevent the later exercise of such a right.
 
-**PROVISIONS ARE SEVERABLE, IF FOUND INVALID**
+## **PROVISIONS ARE SEVERABLE, IF FOUND INVALID**
 
 20.1. If any provision or part-provision of these Terms is or becomes invalid, illegal or unenforceable, it shall be deemed modified to the minimum extent necessary to make it valid, legal and enforceable. If such modification is not possible, the relevant provision or part-provision shall be deemed deleted. Any modification to or deletion of a provision or part-provision under this clause shall not affect the validity and enforceability of the rest of these Terms.
 
-**APPENDIX**
+## **APPENDIX**
 
-**RISKS**
+### **RISKS**
 
-**PRICE FLUCTUATIONS**
-
-ERC20 tokens are neither legal tender backed by governments nor by assets. The tokens' value is highly volatile causing price fluctuations, as auctions typically run for some time and trades are not executed instantly.
-
-**REGULATORY ACTION**
+### **REGULATORY ACTION**
 
 We could be impacted by regulatory inquiries or action, which could impede or limit your ability to access or use the Platform.
 
-**TECHNICAL UNDERSTANDING**
+### **TECHNICAL UNDERSTANDING**
 
 Cryptographic assets are described in technical language requiring a comprehensive understanding of computer science and mathematics to appreciate the inherent risks.
 
 TRANSACTIONS ON ETHEREUM MAINNET AND ETHEREUM VIRTUAL MACHINE COMPATIBLE VALIDATION MECHANISMS ARE IMMUTABLE AND IRREVERSIBLE
 Transactions on Ethereum Mainnet and Ethereum Virtual Machine compatible validation mechanisms are generally immutable and irreversible. Any transaction thereon is therefore irrevocable and final as soon as it is settled thereon. In the event that you send your tokens to sell to any other destination other than the Protocol smart contracts, such tokens may not be returned. We assume no responsibility and shall have no obligation to you if this occurs, including but not limited to any responsibility to recover, or assist to recover, any such tokens.
 
-**FAILURES WITHIN DATA STORAGE SYSTEMS**
+### **FAILURES WITHIN DATA STORAGE SYSTEMS**
 
 Our Platform may in part be established on servers at data centre facilities of third party providers and on distributed systems for storing and accessing data including IPFS. Where centralised services may be used, we may be required to transfer our Platform to different facilities, and may incur service interruption in connection with such relocation. Data centre facilities are vulnerable to force majeure events or other failures. Third party providers may suffer breaches of security and others may obtain unauthorised access to our server data. Where content is stored via distributed systems, there may be interference in content addressing, content linking, indexing and discovery. As techniques used to obtain unauthorised access change frequently and generally are not recognised until used against a target, it may not be possible to anticipate these techniques or to implement adequate preventive measures.


### PR DESCRIPTION
## What was done
removed `<div class="title heading heading3">${title}</div>` on baseDocument.html in order to remove automatically generated titles in the docs. 
<img width="1462" alt="Screen Shot 2022-05-06 at 09 04 27" src="https://user-images.githubusercontent.com/99011533/167083477-1730e5cb-2c2f-4608-8d01-5a20917a8ab3.png">



## Testing
didn't tested

#### Before
nr

#### After
nr