### PR TITLE
953 - feat(discussions): add error when key of undefined

### DIFF
--- a/src/dealDashboard/discussionsService.ts
+++ b/src/dealDashboard/discussionsService.ts
@@ -200,6 +200,10 @@ export class DiscussionsService {
   }
 
   public async importKey(discussionId: string): Promise<CryptoKey> {
+    if (!this.discussions[discussionId]) {
+      throw new Error(`This should not have happened. Cannot find encryption key for discussion with id: ${discussionId}. (There are currenltly ${Object.keys(this.discussions).length} discussions)`);
+    }
+
     return window.crypto.subtle.importKey(
       "jwk",
       {


### PR DESCRIPTION
## What was done
- throw when `this.discussions[discussionId]` is undefined 
  - because later is used for `this.discussions[discussionId].key`. The underlying ticket reported that error
  - spent quite some time to trace how this can happen in the first place, and was just not able to reproduce
  - thus, at least at error handling, so next time we will hopefully know better how to reproduce

:exclamation: I was not able to reproduce

STEPS
1. (after talking with Bartu, he mentioned, this was a newly created partnered deal from "Make an offer" wizard)
2. be disconnected (maybe you have to clear local storage, to be fully disconnected)
3. Navigate to partnered deal from 1.
4. toggle private Deal to true
5. create new comment

EXPECTED
6. I expected a bug as described in the ticket

RESULT
6. actually worked, and could not reproduce

## Testing

#### Before


#### After
https://user-images.githubusercontent.com/30693990/167164621-4ba57872-e122-48eb-8afc-f3ed5c7fa4cc.mp4