### PR TITLE
Funding Page: Header in Deposit section should't get cut at the bottom

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -106,7 +106,7 @@ html {
       &.heading3 {
         @include subHeading;
         font-size: 26px;
-        line-height: 24px;
+        line-height: 29px;
         margin-bottom: 6px;
         color: $Secondary02;
       }


### PR DESCRIPTION
Increased the line-height of the heading3 style globally because they were all getting cut off on the bottom

Before: 
![image](https://user-images.githubusercontent.com/2163332/167721199-4071cc0a-19a4-492c-a690-98f607987d2b.png)

After:
![image](https://user-images.githubusercontent.com/2163332/167721223-003d6781-25f7-4cb8-bc89-c30501280d4e.png)

