### PR TITLE
973-Anchor links are scrolling behind the fixed header

### DIFF
--- a/src/resources/elements/markdown/markdown.scss
+++ b/src/resources/elements/markdown/markdown.scss
@@ -37,6 +37,12 @@
     width: fit-content; // so gradients look right
     white-space: break-word;
     margin-bottom: 28px;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
     scroll-margin-top: 110px;
   }
 
@@ -121,7 +127,10 @@
 
 @media screen and (max-width: $PageBreakWidth) {
   .markdownContainer {
-    h1 {
+    h1,
+    h2,
+    h3,
+    h4 {
       scroll-margin-top: 75px;
     }
   }

--- a/src/resources/elements/markdown/markdown.scss
+++ b/src/resources/elements/markdown/markdown.scss
@@ -37,6 +37,10 @@
     width: fit-content; // so gradients look right
     white-space: break-word;
     margin-bottom: 28px;
+
+    // used for aligning the title correctly in view when jumping to an anchor tag.
+    margin-top: -110px;
+    padding-top: 110px;
   }
 
   a {
@@ -114,6 +118,15 @@
         text-align: center;
         vertical-align: middle;
       }
+    }
+  }
+}
+
+@media screen and (max-width: $PageBreakWidth) {
+  .markdownContainer {
+    h1 {
+      margin-top: -75px;
+      padding-top: 75px;
     }
   }
 }

--- a/src/resources/elements/markdown/markdown.scss
+++ b/src/resources/elements/markdown/markdown.scss
@@ -37,10 +37,7 @@
     width: fit-content; // so gradients look right
     white-space: break-word;
     margin-bottom: 28px;
-
-    // used for aligning the title correctly in view when jumping to an anchor tag.
-    margin-top: -110px;
-    padding-top: 110px;
+    scroll-margin-top: 110px;
   }
 
   a {
@@ -125,8 +122,7 @@
 @media screen and (max-width: $PageBreakWidth) {
   .markdownContainer {
     h1 {
-      margin-top: -75px;
-      padding-top: 75px;
+      scroll-margin-top: 75px;
     }
   }
 }


### PR DESCRIPTION
## What was done
Add `scroll-margin-top` to header elements to correctly position the page after scrolling to an anchor link.

*NOTE:* Images below show test content and not the actual documentation files!

#### Before
![doc-scroll-before](https://user-images.githubusercontent.com/2517870/167832407-1162b1dc-86e5-484d-b25e-9cec75fb8bf9.gif)

#### After

![doc-scroll-after](https://user-images.githubusercontent.com/2517870/167832425-90111e08-6ad2-4026-b638-867b9036b208.gif)

![doc-scroll-mobile](https://user-images.githubusercontent.com/2517870/167832447-648506d5-2914-43ee-9610-29b5bf288752.gif)
