### PR TITLE
set StartingBlockNumber for mainnet

### DIFF
--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -109,7 +109,7 @@ export class DealService {
   ) {
     switch (EthereumService.targetedNetwork) {
       case Networks.Mainnet:
-        StartingBlockNumber = 0;
+        StartingBlockNumber = 14706002;
         break;
       case Networks.Rinkeby:
         StartingBlockNumber = 10578516;

--- a/src/services/DealService.ts
+++ b/src/services/DealService.ts
@@ -107,6 +107,9 @@ export class DealService {
     private ethereumService: EthereumService,
     private taskQueue: TaskQueue,
   ) {
+    /**
+     * set to the block of the creation of the TokenSwapModule
+     */
     switch (EthereumService.targetedNetwork) {
       case Networks.Mainnet:
         StartingBlockNumber = 14706002;


### PR DESCRIPTION
## What was done

set StartingBlockNumber for mainnet to reduce the number of blocks required to search for deals events.  This can significantly reduce the loading time for the application.

## Testing

#### Before

#### After