### PR TITLE
1025 - feat(services): add 1822 storage for proxy contract

### DIFF
--- a/src/services/ContractsService.ts
+++ b/src/services/ContractsService.ts
@@ -159,6 +159,9 @@ export class ContractsService {
   // eip1967.proxy.implementation
   private static storagePosition1967 = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 
+  // eip1822.proxy.implementation
+  private static storagePosition1822 = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
+
   /**
    * Attempts to obtain the addresss of a proxy contract implementation.
    * Uses a heuristic described here:
@@ -175,6 +178,11 @@ export class ContractsService {
     let result = await this.ethereumService.readOnlyProvider.getStorageAt(proxyContract, ContractsService.storagePositionZep);
     if (BigNumber.from(result).isZero()) {
       result = await this.ethereumService.readOnlyProvider.getStorageAt(proxyContract, ContractsService.storagePosition1967);
+    }
+
+    /** Still zero? Try again with 1822 */
+    if (BigNumber.from(result).isZero()) {
+      result = await this.ethereumService.readOnlyProvider.getStorageAt(proxyContract, ContractsService.storagePosition1822);
     }
 
     const bnResult = BigNumber.from(result);


### PR DESCRIPTION
## What was done
wCELO is based on [EIP-1822 Universal Upgradeable Proxy](https://eips.ethereum.org/EIPS/eip-1822), which points to storage position 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7

https://etherscan.io/address/0xE452E6Ea2dDeB012e20dB73bf5d3863A3Ac8d77a#readProxyContract

## Testing
Locally, you have to change the package script to run on mainnet, eg
```
"start-dev": "cross-env DOTENV_CONFIG_PATH=.env NETWORK=mainnet webpack-dev-server --env development --open",
```

#### Before

#### After
token shows up