### PR TITLE
1027 - Make partnered deals card default

### DIFF
--- a/src/deals/list/deals.ts
+++ b/src/deals/list/deals.ts
@@ -56,7 +56,7 @@ export class Deals {
     this.dealsLoading = false;
 
     if (this.cardIndex === undefined) {
-      this.cardIndex = this.dealService.openProposals?.length ? 0 : 1;
+      this.cardIndex = this.dealService.partneredDeals?.length ? 1 : 0;
     }
     this.sortDirection = SortOrder.DESC;
     this.sort("age");

--- a/src/home/home.ts
+++ b/src/home/home.ts
@@ -8,8 +8,8 @@ type DealType = "open" | "partnered";
 @singleton(false) // to maintain tab selection state
 @autoinject
 export class Home {
-  private cardIndex = 0;
-  private dealType:DealType = "open";
+  private cardIndex = 1;
+  private dealType:DealType = "partnered";
   private dealsLoading = false;
   static MAX_DEALS_COUNT=10;
 
@@ -38,7 +38,7 @@ export class Home {
     this.dealsLoading = false;
 
     if (this.cardIndex === undefined) {
-      this.cardIndex = this.allDeals.open.length ? 0 : 1;
+      this.cardIndex = this.allDeals.partnered.length ? 1 : 0;
     }
   }
 


### PR DESCRIPTION
## What was done
Set the `Partnered Deals` tab as default on the `Home` and `Deals`pages.
