### PR TITLE
1038 - feat(services): add allowList for "custom proxy" tokens

### DIFF
--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -31,6 +31,12 @@ const allowListTokenMap: AllowListTokenMap = {
   },
 };
 
+function isAllowListToken(tokenAddress: string): boolean {
+  if (EthereumService.targetedNetwork !== "mainnet") return false;
+
+  return Object.keys(allowListTokenMap).includes(tokenAddress);
+}
+
 @autoinject
 export class TokenService {
 
@@ -219,7 +225,7 @@ export class TokenService {
   }
 
   public async getTokenInfoFromAddress(tokenAddress: Address): Promise<ITokenInfo> {
-    if (Object.keys(allowListTokenMap).includes(tokenAddress)) {
+    if (isAllowListToken(tokenAddress)) {
       return Promise.resolve(allowListTokenMap[tokenAddress]);
     }
 
@@ -308,7 +314,7 @@ export class TokenService {
   }
 
   public async isERC20Token(tokenAddress: Address): Promise<boolean> {
-    if (Object.keys(allowListTokenMap).includes(tokenAddress)) {
+    if (isAllowListToken(tokenAddress)) {
       return Promise.resolve(true);
     }
 

--- a/src/services/TokenService.ts
+++ b/src/services/TokenService.ts
@@ -13,6 +13,24 @@ import TokenMetadataService from "services/TokenMetadataService";
 import { AxiosService } from "services/axiosService";
 import { TimingService } from "services/TimingService";
 
+type AllowListTokenMap = Record<string, ITokenInfo>
+
+const allowListTokenMap: AllowListTokenMap = {
+  /**
+   * FIXME: Find a way to validate custom proxy implementation.
+   *   Celo token on Ethererum uses a custom proxy implementation
+   *   https://etherscan.io/address/0xC95DC0ECEEC11aB8b2BFa1AfF3C223C5dC006fAD#readProxyContract
+   *   Since we have not found a way to validate it programmatically, use this allow list.
+   */
+  "0xC95DC0ECEEC11aB8b2BFa1AfF3C223C5dC006fAD": {
+    address: "0xC95DC0ECEEC11aB8b2BFa1AfF3C223C5dC006fAD",
+    name: "Celo",
+    symbol: "CELO",
+    decimals: 18,
+    logoURI: "https://s2.coinmarketcap.com/static/img/coins/64x64/5567.png",
+  },
+};
+
 @autoinject
 export class TokenService {
 
@@ -201,6 +219,9 @@ export class TokenService {
   }
 
   public async getTokenInfoFromAddress(tokenAddress: Address): Promise<ITokenInfo> {
+    if (Object.keys(allowListTokenMap).includes(tokenAddress)) {
+      return Promise.resolve(allowListTokenMap[tokenAddress]);
+    }
 
     let resolver: (value: ITokenInfo | PromiseLike<ITokenInfo>) => void;
     let rejector: (reason?: any) => void;
@@ -287,6 +308,10 @@ export class TokenService {
   }
 
   public async isERC20Token(tokenAddress: Address): Promise<boolean> {
+    if (Object.keys(allowListTokenMap).includes(tokenAddress)) {
+      return Promise.resolve(true);
+    }
+
     let isOk = true;
 
     TimingService.start(`isERC20Token-${tokenAddress}`);


### PR DESCRIPTION
## What was done
Celo token on Ethererum uses a custom proxy implementation, that we cannot verify as a ERC20 token atm. 
https://etherscan.io/address/0xC95DC0ECEEC11aB8b2BFa1AfF3C223C5dC006fAD#readProxyContract
Since we have not found a way to validate it programmatically, use allow list.

## Testing
// if locally, then:
1. edit the `start-dev` script to run on "mainnet"

// if vercel preview, then I updated that branch to run on mainnet
![image](https://user-images.githubusercontent.com/30693990/171037485-5ef0b64e-8de1-4bb3-92a5-13c23ca01907.png)


2. wizard
3. tokenDetails
4. `0xC95DC0ECEEC11aB8b2BFa1AfF3C223C5dC006fAD`

#### Before
error
#### After
works
![image](https://user-images.githubusercontent.com/30693990/171035403-0e34360b-1431-444b-97d1-af33c9e26c0c.png)
