### PR TITLE
Add logging to for funding flow

### DIFF
--- a/src/funding/funding.ts
+++ b/src/funding/funding.ts
@@ -21,6 +21,8 @@ import { IAlertModel } from "services/AlertService";
 import { IGridColumn } from "resources/elements/primeDesignSystem/pgrid/pgrid";
 import { depositColumns, claimTokenGridColumns } from "./funding-grid-columns";
 import { AureliaHelperService } from "services/AureliaHelperService";
+import { formatBytes32String } from "ethers/lib/utils";
+import { ConsoleLogService } from "services/ConsoleLogService";
 
 @autoinject
 export class Funding {
@@ -57,6 +59,7 @@ export class Funding {
     private alertService: AlertService,
     private tokenService: TokenService,
     private aureliaHelperService: AureliaHelperService,
+    private consoleLogService: ConsoleLogService,
   ) {
     this.eventAggregator.subscribe("Network.Changed.Account", async (): Promise<void> => {
       //This is for the page to redirect to the home page if the user changes their account address while on the funding page and their new account address isn't part of this deal
@@ -76,6 +79,12 @@ export class Funding {
     if (!this.deal.fundingWasInitiated) this.goToDealPage();
     //Make sure the connected account is part of this deal. Otherwise redirect to home page.
     this.verifySecurity();
+
+    const contractDealId = await this.deal.moduleContract.metadataToDealId(formatBytes32String(this.dealId));
+    this.consoleLogService.logMessage(">>>>> Start Funding logs <<<<<");
+    this.consoleLogService.logMessage(`2.1 [Funding#activate] dealId: ${this.dealId}`);
+    this.consoleLogService.logMessage(`2.2 [Funding#activate] contractDealId: ${contractDealId}`);
+
     //wait until the dao transactions from the contract are there
     await Utils.waitUntilTrue(() => this.deal.daoTokenTransactions !== undefined);
     //wait until the dao token claims from the contract are there
@@ -91,6 +100,9 @@ export class Funding {
     await this.deal.hydrateDaoTransactions();
     //get contract token information from the other DAO
     if (this.deal.isFunding || this.deal.isFailed){
+      this.consoleLogService.logMessage(`3.1 [#initializeData] isFunding: ${this.deal.isFunding}`);
+      this.consoleLogService.logMessage(`3.2 [#initializeData] isFailed: ${this.deal.isFailed}`);
+
       await this.setTokenFundingData();
       if (!this.deal.isFailed && this.firstDao.tokens.length === 1) {
         //if there is only one token, auto select it in the deposit form
@@ -100,6 +112,8 @@ export class Funding {
         await this.setFundingTokenAllowance();
       }
     } else if (this.deal.isClaiming){
+      this.consoleLogService.logMessage(`3.3 [Funding#initializeData] isClaiming: ${this.deal.isClaiming}`);
+
       await this.setTokenClaimingData();
     }
   }
@@ -325,12 +339,16 @@ export class Funding {
     if (this.selectedToken !== null && this.selectedToken >= 0){
       const contract = this.tokenService.getTokenContract(this.firstDao.tokens[this.selectedToken].address);
       this.accountBalance = await contract.balanceOf(this.ethereumService.defaultAccountAddress);
+
+      this.consoleLogService.logMessage(`6. [Funding#setAccountBalance] accountBalance: ${this.accountBalance}`);
     }
   }
 
   public async setFundingTokenAllowance(): Promise<void> {
     const contract = this.tokenService.getTokenContract(this.firstDao.tokens[this.selectedToken].address);
     this.userFundingTokenAllowance = await contract.allowance(this.ethereumService.defaultAccountAddress, this.deal.daoDepositContracts.get(this.firstDao).address);
+
+    this.consoleLogService.logMessage(`7. [Funding#setFundingTokenAllowance] userFundingTokenAllowance: ${this.userFundingTokenAllowance}`);
   }
 
   @computedFrom("deal.isRepresentativeUser", "deal.daoRepresentedByCurrentAccount", "deal.primaryDao")
@@ -374,6 +392,8 @@ export class Funding {
     this.processing = true;
     const transaction = await this.deal.claim(this.firstDao);
     if (transaction){
+      this.consoleLogService.logObject("9. [Funding#claimTokens] transaction: ", transaction);
+
       const congratulatePopupModel: IAlertModel = {
         header: "Congratulations!",
         message: "<p class='excitement'>You have successfully claimed your tokens!</p>",

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,20 @@ import { ValidationService } from "./services/ValidationService";
 import { DealService } from "services/DealService";
 import { initialize as initializeMarkdown} from "resources/elements/markdown/markdown";
 
+const FORCE_DEBUG = "[Prime] FORCE_DEBUG";
+// @ts-ignore
+window.primeDebug = {
+  on: () => {
+    localStorage.setItem(FORCE_DEBUG, "true");
+  },
+  off: () => {
+    localStorage.removeItem(FORCE_DEBUG);
+  },
+  check: () => {
+    return localStorage.getItem(FORCE_DEBUG);
+  },
+};
+
 export function configure(aurelia: Aurelia): void {
   // Note, this Cypress hack has to be at the very start.
   // Reason: Imports in eg. /resources/index, where EthereumService is imported to
@@ -50,8 +64,11 @@ export function configure(aurelia: Aurelia): void {
 
   const network = process.env.NETWORK as AllowedNetworks;
   const inDev = process.env.NODE_ENV === "development";
+  const isForceDebug = window.localStorage.getItem(FORCE_DEBUG);
 
-  if (inDev) {
+  if (isForceDebug === "true") {
+    aurelia.use.developmentLogging(); // everything
+  } else if (inDev) {
     aurelia.use.developmentLogging(); // everything
   } else {
     aurelia.use.developmentLogging("warn"); // only errors and warnings

--- a/src/services/ConsoleLogService.ts
+++ b/src/services/ConsoleLogService.ts
@@ -112,4 +112,23 @@ export class ConsoleLogService {
         break;
     }
   }
+
+  public logObject(msg: string, obj: any, level: ConsoleLogMessageTypes = "info"): void {
+    switch (level) {
+      case "info":
+      default:
+        this.logger.info(msg, obj);
+        break;
+      case "warn":
+      case "warning":
+        this.logger.warn(msg, obj);
+        break;
+      case "error":
+        this.logger.error(msg, obj);
+        break;
+      case "debug":
+        this.logger.debug(msg, obj);
+        break;
+    }
+  }
 }


### PR DESCRIPTION
## What was done
- Add more logs
- make the logging opt-in on production
  - `primeDebug.on()` and use localStorage was the quickest solution I could think of

- production logging api
```ts
primeDebug.on() 
primeDebug.off() 
primeDebug.check() 
```

## Testing
0. do a production build `npm run build-dev` (change to `--env production`) then `npm run serve`)
1. open the console
2. type in `primeDebug.on()`
3. reload the page
4. (check if logging is on via `primeDebug.check()`)
5. (turn off via `primeDebug.off()`)
6. navigate to the app

#### Before
![image](https://user-images.githubusercontent.com/30693990/171639020-04e35804-12fe-4fe5-a3ed-efabd81ee2b4.png)


#### After
![image](https://user-images.githubusercontent.com/30693990/171638972-b1df6799-5f58-4aba-bf72-241457b83d5c.png)
