### PR TITLE
add mobile responsiveness to the all-deals page.

### DIFF
--- a/src/deals/dealSummary/dealSummary.scss
+++ b/src/deals/dealSummary/dealSummary.scss
@@ -4,8 +4,7 @@
 deal-summary {
   .pcard {
     display: inline-block;
-    max-width: 360px;
-    min-width: 360px;
+    width: 360px;
     background-color: $BG02;
     padding: $spacing-normal;
     /* don't do this transition until we can do it with gradient pcards too
@@ -109,34 +108,11 @@ deal-summary {
     }
   }
 }
-
-@media screen and (max-width: $PageBreakWidth) {
-  .dealSummaryContainer {
-    // because this is going to be vertically-aligned
-    padding-right: 0;
-    margin-bottom: 20px;
-    width: 50%;
-
-    .dealSummary {
-      > .icon {
-        img {
-          height: 36px;
-          width: 36px;
-        }
-      }
-
-      > .footer,
-      > .countdown,
-      > .proposal {
-        text-align: left;
-      }
-    }
-  }
-}
-
 @media screen and (max-width: 400px) {
-  .dealSummaryContainer {
-    min-width: 100%;
-    width: 100%;
+  deal-summary {
+    .pcard {
+      width: 100%;
+      max-width: 360px;
+    }
   }
 }

--- a/src/deals/dealSummary/dealSummary.scss
+++ b/src/deals/dealSummary/dealSummary.scss
@@ -108,7 +108,8 @@ deal-summary {
     }
   }
 }
-@media screen and (max-width: 400px) {
+
+@media screen and (max-width: $PageBreakWidth) {
   deal-summary {
     .pcard {
       width: 100%;

--- a/src/deals/dealSummary/dealSummary.scss
+++ b/src/deals/dealSummary/dealSummary.scss
@@ -109,11 +109,11 @@ deal-summary {
   }
 }
 
-@media screen and (max-width: $PageBreakWidth) {
-  deal-summary {
-    .pcard {
-      width: 100%;
-      max-width: 360px;
-    }
-  }
-}
+// @media screen and (max-width: $PageBreakWidth) {
+//   deal-summary {
+//     .pcard {
+//       width: 100%;
+//       max-width: 360px;
+//     }
+//   }
+// }

--- a/src/deals/list/deals.scss
+++ b/src/deals/list/deals.scss
@@ -339,6 +339,10 @@ pbutton button.secondary {
       }
 
       &.all-deals {
+        .heading02Gradient {
+          padding-bottom: $spacing-small;
+          border-bottom: 1px solid $Border01;
+        }
         .grid.dealGrid {
           grid-template-columns: 1fr;
           .row {
@@ -356,10 +360,6 @@ pbutton button.secondary {
             }
             &.header {
               display: none;
-            }
-            &:first-of-type {
-              margin-top: $spacing-small;
-              border-top: 1px solid $Border01;
             }
             .cell {
               padding: 0 $spacing-normal;

--- a/src/deals/list/deals.scss
+++ b/src/deals/list/deals.scss
@@ -62,7 +62,7 @@ pbutton button.secondary {
       text-align: right;
       margin-bottom: 28px;
       display: grid;
-      grid-template-columns: 1fr auto;
+      grid-template: 1fr / 1fr auto;
       justify-items: right;
       align-items: center;
 
@@ -188,7 +188,7 @@ pbutton button.secondary {
 
       .dealGrid {
         display: grid;
-        grid-template-columns: 0.6fr 0.9fr 0.5fr 0.5fr 0.5fr 0.5fr;
+        grid-template-columns: 2fr 3fr 1fr 1fr 1fr 1fr;
 
         .row {
           &.header {
@@ -322,9 +322,82 @@ pbutton button.secondary {
   }
 }
 
+@mixin prefix($text) {
+  &:before {
+    content: $text;
+    margin-right: $spacing-small;
+    font-size: small;
+  }
+}
+
 @media screen and (max-width: $PageBreakWidth) {
   .page.deals {
     .section {
+      &.deals-actions {
+        grid-template: 1fr auto / 1fr;
+        grid-row-gap: $spacing-normal;
+      }
+
+      &.all-deals {
+        .grid.dealGrid {
+          grid-template-columns: 1fr;
+          .row {
+            display: grid;
+            padding: $spacing-small 0;
+            grid-template-areas:
+              "daos daos status"
+              "type type age"
+              "title title size";
+            grid-template-columns: 2fr 2fr 1fr;
+            grid-template-rows: 40px 20px auto;
+            border-bottom: 1px solid $Border01;
+            &.body.hot:hover {
+              background-color: $BG02;
+            }
+            &.header {
+              display: none;
+            }
+            &:first-of-type {
+              margin-top: $spacing-small;
+              border-top: 1px solid $Border01;
+            }
+            .cell {
+              padding: 0 $spacing-normal;
+              border-bottom: unset;
+              height: auto;
+            }
+            .project {
+              grid-area: daos;
+            }
+            .title {
+              grid-area: title;
+              font-size: 20px;
+              font-weight: bold;
+            }
+            .type {
+              justify-content: left;
+              grid-area: type;
+              font-size: 12px;
+              font-weight: bold;
+              color: $Secondary05;
+              text-transform: uppercase;
+            }
+            .status {
+              justify-content: center;
+              grid-area: status;
+            }
+            .age {
+              grid-area: age;
+              justify-content: center;
+            }
+            .dealSize {
+              @include prefix("Deal Size (USD):");
+              justify-content: center;
+              grid-area: size;
+            }
+          }
+        }
+      }
       > .title {
         white-space: normal;
         text-align: center;
@@ -335,6 +408,35 @@ pbutton button.secondary {
       &.featured {
         .scrollerContainer {
           margin-bottom: 0;
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 400px) {
+  .page.deals {
+    .section {
+      &.all-deals {
+        .grid.dealGrid {
+          .row {
+            grid-template-areas:
+              "daos daos daos"
+              "type type type"
+              "size size status";
+            grid-template-columns: 2fr 1fr 0.5fr;
+            .title, .age {
+              display: none;
+            }
+            &.body {
+              padding-top: $spacing-normal;
+              padding-bottom: $spacing-normal;
+            }
+            .dealSize {
+              @include prefix("");
+              justify-content: left;
+            }
+          }
         }
       }
     }

--- a/src/deals/list/deals.scss
+++ b/src/deals/list/deals.scss
@@ -373,6 +373,7 @@ pbutton button.secondary {
               grid-area: title;
               font-size: 20px;
               font-weight: bold;
+              overflow-wrap: anywhere;
             }
             .type {
               justify-content: left;
@@ -414,7 +415,7 @@ pbutton button.secondary {
   }
 }
 
-@media screen and (max-width: 400px) {
+@media screen and (max-width: $MobileWidth) {
   .page.deals {
     .section {
       &.all-deals {

--- a/src/resources/elements/primeDesignSystem/_carousel.scss
+++ b/src/resources/elements/primeDesignSystem/_carousel.scss
@@ -81,6 +81,12 @@
   }
 }
 
+@media screen and (max-width: 900px) and (min-width: 550px) {
+  .deal-carousel {
+    padding: 0 45px;
+  }
+}
+
 @media screen and (max-width: $PageBreakWidth) {
   .deal-carousel {
     .carousel-selector {

--- a/src/resources/elements/primeDesignSystem/_carousel.scss
+++ b/src/resources/elements/primeDesignSystem/_carousel.scss
@@ -81,12 +81,6 @@
   }
 }
 
-@media screen and (max-width: 900px) and (min-width: 550px) {
-  .deal-carousel {
-    padding: 0 45px;
-  }
-}
-
 @media screen and (max-width: $PageBreakWidth) {
   .deal-carousel {
     .carousel-selector {


### PR DESCRIPTION
## What was done
Rearranged the table to fit into mobile screens.
Small mobile (phones) should not show the titles and the age in the deals table (reduced clutter).
As a result- there is no h-scrollbar anymore on this page.

Approved by @v0ort 

#### Before
<img src="https://user-images.githubusercontent.com/2517870/172871142-3b86786c-eff2-443d-ae61-c25e57ad3c62.png" width="360" alt="before view">

#### After
Phone:
<img src="https://user-images.githubusercontent.com/2517870/174772800-47d290a5-1f70-47e4-b426-cd09ceb38775.png" width="360" alt="after view- phone">
Tablet:
<img src="https://user-images.githubusercontent.com/2517870/174773181-e89d57b5-e2f6-442c-8db2-45aeb0006061.png" width="768" alt="after view- tablet">
