### PR TITLE
1056-Remove carousel from all deals page and keep it horizontal on the home page

### DIFF
--- a/src/deals/list/deals.scss
+++ b/src/deals/list/deals.scss
@@ -324,6 +324,19 @@ pbutton button.secondary {
 
 @media screen and (max-width: $PageBreakWidth) {
   .page.deals {
+    .deal-carousel {
+      min-height: unset;
+      margin-bottom: unset;
+      .carousel-selector {
+        margin-bottom: unset;
+      }
+      .featuredDealsScroller {
+        display: none;
+      }
+    }
+    .all-deals .heading02Gradient {
+      display: none;
+    }
     .section {
       > .title {
         white-space: normal;

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -124,6 +124,14 @@
           margin-bottom: 80px;
           gap: 28px;
         }
+
+        .scrollerContainer {
+          width: calc(100vw - 145px);
+          .scroller {
+            flex-direction: row;
+            gap: $spacing-normal;
+          }
+        }
       }
 
       &.hero {
@@ -132,5 +140,11 @@
         margin-bottom: 0;
       }
     }
+  }
+}
+
+@media screen and (max-width: 549px) {
+  .page.home>.section.top>.scrollerContainer {
+    width: calc(100vw - 55px);
   }
 }

--- a/src/home/home.scss
+++ b/src/home/home.scss
@@ -126,10 +126,9 @@
         }
 
         .scrollerContainer {
-          width: calc(100vw - 145px);
           .scroller {
             flex-direction: row;
-            gap: $spacing-normal;
+            gap: calc($spacing-normal * 2);
           }
         }
       }
@@ -140,11 +139,5 @@
         margin-bottom: 0;
       }
     }
-  }
-}
-
-@media screen and (max-width: 549px) {
-  .page.home>.section.top>.scrollerContainer {
-    width: calc(100vw - 55px);
   }
 }

--- a/src/resources/elements/horizontal-scroller/horizontal-scroller.scss
+++ b/src/resources/elements/horizontal-scroller/horizontal-scroller.scss
@@ -68,24 +68,3 @@
     left: -16px;
   }
 }
-
-@media screen and (max-width: $PageBreakWidth) {
-  .scrollerContainer {
-    display: block;
-    position: unset;
-    text-align: center;
-
-    .scroller {
-      flex-direction: column;
-
-      > div:not(:last-of-type) {
-        margin-bottom: 24px;
-      }
-    }
-
-    .rightButton,
-    .leftButton {
-      display: none;
-    }
-  }
-}

--- a/src/resources/elements/horizontal-scroller/horizontal-scroller.ts
+++ b/src/resources/elements/horizontal-scroller/horizontal-scroller.ts
@@ -39,7 +39,9 @@ export class HorizontalScroller {
     /**
      * scroll by the sum of the widths of the wholly-visible items
      */
-    return itemWidth * visibleItemsCount;
+    console.log("visibleWidth", visibleWidth, "itemWidth", itemWidth, "visibleItemsCount", visibleItemsCount);
+
+    return itemWidth * visibleItemsCount || itemWidth/* fix: visibleItemsCount is 0 */;
   }
 
   @computedFrom("scroller.scrollWidth", "scrollPos", "scroller.clientWidth")

--- a/src/resources/elements/horizontal-scroller/horizontal-scroller.ts
+++ b/src/resources/elements/horizontal-scroller/horizontal-scroller.ts
@@ -39,8 +39,6 @@ export class HorizontalScroller {
     /**
      * scroll by the sum of the widths of the wholly-visible items
      */
-    console.log("visibleWidth", visibleWidth, "itemWidth", itemWidth, "visibleItemsCount", visibleItemsCount);
-
     return itemWidth * visibleItemsCount || itemWidth/* fix: visibleItemsCount is 0 */;
   }
 


### PR DESCRIPTION
## What was done
### Homepage
Reverted the featured deals carousel to be horizontal-oriented in smaller screen sizes.

### All-Deals page
Removed the featured deals carousel from smaller screen sizes.

### Important Note: After merging both this PR **and** PR #1069 the following code should be removed:

```javascript
// dealSummary.scss

@media screen and (max-width: $PageBreakWidth) {
  deal-summary {
    .pcard {
      width: 100%;
      max-width: 360px;
    }
  }
}
```
