### PR TITLE
1056- Removed unneeded code from dealSummary.scss 

### DIFF
--- a/src/deals/dealSummary/dealSummary.scss
+++ b/src/deals/dealSummary/dealSummary.scss
@@ -108,12 +108,3 @@ deal-summary {
     }
   }
 }
-
-// @media screen and (max-width: $PageBreakWidth) {
-//   deal-summary {
-//     .pcard {
-//       width: 100%;
-//       max-width: 360px;
-//     }
-//   }
-// }


### PR DESCRIPTION
## What was done
Removed an unneeded, commented-out code at the end of `dealSummarry.scss`.

Resolves a leftover from merging the PRs that remove the featured-deals carousel #1070 and add responsiveness to the table in mobile views #1069  (for the `all-deals` page.