### PR TITLE
Feat/1060 swap execution etherscan link on deal dashboard

### DIFF
--- a/src/dealDashboard/dealVotes/dealVotes.html
+++ b/src/dealDashboard/dealVotes/dealVotes.html
@@ -58,7 +58,15 @@
       ></deal-representatives-votes>
 
       <p class="bodySmallText votesSubtitle" if.bind="statusText">Deal status</p>
-      <div class="orangeColor dealStatusText">${statusText.statusText}</div>
+      <div class="orangeColor dealStatusText">
+        ${statusText.statusText}
+        <etherscanlink if.bind="(deal.isClaiming || deal.isCompleted) && deal.swapTxHash"
+          text="View on Etherscan"
+          type="tx"
+          address="${deal.swapTxHash}"
+          hide-clipboard-button>
+        </etherscanlink>
+      </div>
     </div>
 
     <div

--- a/src/dealDashboard/dealVotes/dealVotes.scss
+++ b/src/dealDashboard/dealVotes/dealVotes.scss
@@ -68,7 +68,7 @@ deal-votes {
           }
 
           object svg path {
-            fill: red
+            fill: red;
           }
         }
       }
@@ -82,6 +82,22 @@ deal-votes {
 
       .dealStatusText {
         font-size: 14px;
+        display: flex;
+        width: 100%;
+        justify-content: space-between;
+        etherscanlink {
+          a {
+            color: $Neutral02;
+            &::after {
+              content: "↗";
+              color: $Secondary05;
+              display: inline-block;
+              vertical-align: middle;
+              text-align: right;
+              width: 18px;
+            }
+          }
+        }
       }
 
       .representativesVotesSubtitle {

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -120,6 +120,7 @@ export class DealTokenSwap implements IDeal {
   public dealManager: any;
 
   public primaryDao?: IDAO;
+  public swapTxHash?: string;
 
   constructor(
     private consoleLogService: ConsoleLogService,
@@ -570,6 +571,7 @@ export class DealTokenSwap implements IDeal {
       this.primaryDao = this.registrationData.primaryDAO;
       this.partnerDao = this.registrationData.partnerDAO;
       this.createdAt = new Date(this.dealDocument.createdAt);
+      this.swapTxHash = this.dealDocument.swapTxHash || null;
 
       await this.loadDepositContracts(); // now that we have registrationData
 
@@ -791,10 +793,11 @@ export class DealTokenSwap implements IDeal {
           if (receipt) {
             this.isExecuted = true;
             this.executedAt = new Date((await this.ethereumService.getBlock(receipt.blockNumber)).timestamp * 1000);
+            this.swapTxHash = receipt.transactionHash;
             this.dataSourceDeals.updateSwapTxHash(
               this.dealDocument.id,
               this.ethereumService.defaultAccountAddress,
-              receipt.transactionHash,
+              this.swapTxHash,
             );
             return receipt;
           }

--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -791,6 +791,11 @@ export class DealTokenSwap implements IDeal {
           if (receipt) {
             this.isExecuted = true;
             this.executedAt = new Date((await this.ethereumService.getBlock(receipt.blockNumber)).timestamp * 1000);
+            this.dataSourceDeals.updateSwapTxHash(
+              this.dealDocument.id,
+              this.ethereumService.defaultAccountAddress,
+              receipt.transactionHash,
+            );
             return receipt;
           }
         });

--- a/src/entities/IDealTypes.ts
+++ b/src/entities/IDealTypes.ts
@@ -28,6 +28,7 @@ export interface IDealTokenSwapDocument {
   createdByAddress: string;
   isWithdrawn: boolean,
   isRejected: boolean,
+  swapTxHash?: string,
 }
 
 export enum DealStatus {

--- a/src/services/DataSourceDealsTypes.ts
+++ b/src/services/DataSourceDealsTypes.ts
@@ -4,7 +4,7 @@ import { Observable } from "rxjs";
 import { IDealDiscussion } from "entities/DealDiscussions";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
-import { Address } from "./EthereumService";
+import { Address, Hash } from "./EthereumService";
 
 export type IDealIdType = string;
 
@@ -116,6 +116,17 @@ export interface IDataSourceDeals {
     dealId: IDealIdType,
     accountAddress: Address,
     value: boolean,
+  ): Promise<void>;
+  /**
+   * Update swapTxHash property
+   * @param dealId
+   * @param accountAddress
+   * @param value
+   */
+  updateSwapTxHash(
+    dealId: IDealIdType,
+    accountAddress: Address,
+    value: Hash,
   ): Promise<void>;
   /**
    * Should we ask user to sign authentication message

--- a/src/services/FirestoreDealsService.ts
+++ b/src/services/FirestoreDealsService.ts
@@ -4,7 +4,7 @@ import { FirestoreService } from "services/FirestoreService";
 import { IDataSourceDeals } from "services/DataSourceDealsTypes";
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import { IDealRegistrationTokenSwap } from "entities/DealRegistrationTokenSwap";
-import { Address, IEthereumService } from "services/EthereumService";
+import { Address, Hash, IEthereumService } from "services/EthereumService";
 import { IFirebaseDocument } from "services/FirestoreTypes";
 import { ConsoleLogService } from "services/ConsoleLogService";
 import { Observable } from "rxjs";
@@ -98,6 +98,14 @@ export class FirestoreDealsService<
     }
 
     return this.firestoreService.updateDealIsRejected(dealId, value);
+  }
+
+  public updateSwapTxHash(dealId: string, accountAddress: string, value: Hash): Promise<void> {
+    if (!this.isUserAuthenticatedWithAddress(accountAddress)) {
+      return;
+    }
+
+    return this.firestoreService.updateSwapTxHash(dealId, value);
   }
 
   public getDealById<TDealDocument>(dealId: string): Promise<TDealDocument> {

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -24,6 +24,7 @@ import { DEALS_TOKEN_SWAP_COLLECTION, DEALS_TOKEN_SWAP_UPDATES_COLLECTION, IFire
 import { IDealTokenSwapDocument } from "entities/IDealTypes";
 import axios from "axios";
 import { IDealDiscussion } from "entities/DealDiscussions";
+import { Hash } from "./EthereumService";
 
 /**
  * TODO: Should define a new place for this type, and all other `Address` imports should take it from there
@@ -327,6 +328,26 @@ export class FirestoreService<
         ref,
         {
           isRejected: value,
+        },
+        {merge: true},
+      );
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+   * Sets deal swap transaction hash property
+   * @param dealId string
+   * @param value Hash
+   */
+  public async updateSwapTxHash(dealId: string, value: Hash): Promise<void> {
+    try {
+      const ref = doc(firebaseDatabase, DEALS_TOKEN_SWAP_COLLECTION, dealId);
+      await setDoc(
+        ref,
+        {
+          swapTxHash: value,
         },
         {merge: true},
       );


### PR DESCRIPTION
## What was done
1. Added firebase action to enable storing the swap transaction hash into the deal document.
2. Added an Etherscan link to the voting section once a deal is in a `claiming` or `completed` state.

<img src="https://user-images.githubusercontent.com/2517870/176431685-0a485ee1-9163-4a35-81ae-3412de738404.png" width="350"> <img src="https://user-images.githubusercontent.com/2517870/176431665-45c51082-cfbb-4f15-bba6-54766de594dd.png" width="350">
