### PR TITLE
1077- DAOplomat rewards - Dashboard

### DIFF
--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -151,7 +151,7 @@
       <span class="bodySmallTextBold infoTitle">Total DAOplomat Reward</span>
       <span>
         <span class="reward-percent">
-          ${deal.registrationData.terms.daoplomatRewards.percentage}
+          ${deal.registrationData.terms.daoplomatRewards.percentage * 100}
         </span>
         <i class="fas fa-angle-down arrow"></i>
       </span>
@@ -166,7 +166,7 @@
             class="representative-dao" 
             address.bind="daoplomat.address"
             text="${daoplomat.address | smallHexString}"></etherscanlink>
-          <span class="reward-percent">${daoplomat.rewardSplitPercentage * deal.registrationData.terms.daoplomatRewards.percentage / 100}</span>
+          <span class="reward-percent">${daoplomat.rewardSplitPercentage * 100}</span>
         </p>
       </div>
     </div>

--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -144,7 +144,7 @@
       </etherscanlink>
     </div>
 
-    <div
+    <div if.bind="deal.registrationData.terms.daoplomatRewards"
       class="infoSection totalRepresentatives ${showMoreRewards ? 'active' : ''}"
       click.trigger="showMoreRewards = !showMoreRewards"
     >

--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -146,7 +146,7 @@
 
     <div if.bind="deal.registrationData.terms.daoplomatRewards"
       class="infoSection totalRepresentatives ${showMoreRewards ? 'active' : ''}"
-      click.trigger="showMoreRewards = !showMoreRewards"
+      click.delegate="showMoreRewards = !showMoreRewards"
     >
       <span class="bodySmallTextBold infoTitle">Total DAOplomat Reward</span>
       <span>
@@ -173,7 +173,7 @@
 
     <div
       class="infoSection totalRepresentatives ${showMoreRepresentatives ? 'active' : ''}"
-      click.trigger="showMoreRepresentatives = !showMoreRepresentatives"
+      click.delegate="showMoreRepresentatives = !showMoreRepresentatives"
     >
       <span class="bodySmallTextBold infoTitle">Total representatives</span>
       <span>

--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -145,8 +145,35 @@
     </div>
 
     <div
-      class="infoSection totalRepresentatives ${showMore ? 'active' : ''}"
-      click.trigger="showMore = !showMore"
+      class="infoSection totalRepresentatives ${showMoreRewards ? 'active' : ''}"
+      click.trigger="showMoreRewards = !showMoreRewards"
+    >
+      <span class="bodySmallTextBold infoTitle">Total DAOplomat Reward</span>
+      <span>
+        <span class="percent">
+          ${deal.registrationData.terms.daoplomatRewards.percentageAmount}
+        </span>
+        <i class="fas fa-angle-down arrow"></i>
+      </span>
+    </div>
+    <div class="panel" css.bind="{'max-height': maxHeightRewards}" ref="panelRewards">
+      <div class="panel-content">
+        <p
+          class="representative bodySmallText"
+          repeat.for="daoplomat of deal.registrationData.terms.daoplomatRewards.daoplomats"
+        >
+          <etherscanlink 
+            class="representative-dao" 
+            address.bind="daoplomat.address"
+            text="${daoplomat.address | smallHexString}"></etherscanlink>
+          <span class="percent">${daoplomat.percentageAmount * deal.registrationData.terms.daoplomatRewards.percentageAmount / 100}</span>
+        </p>
+      </div>
+    </div>
+
+    <div
+      class="infoSection totalRepresentatives ${showMoreRepresentatives ? 'active' : ''}"
+      click.trigger="showMoreRepresentatives = !showMoreRepresentatives"
     >
       <span class="bodySmallTextBold infoTitle">Total representatives</span>
       <span>
@@ -156,7 +183,7 @@
         <i class="fas fa-angle-down arrow"></i>
       </span>
     </div>
-    <div class="panel" css.bind="{'max-height': maxHeight}" ref="panel">
+    <div class="panel" css.bind="{'max-height': maxHeightRepresentatives}" ref="panelRepresentatives">
       <div class="panel-content">
         <p
           class="representative bodySmallText"

--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -166,7 +166,7 @@
             class="representative-dao" 
             address.bind="daoplomat.address"
             text="${daoplomat.address | smallHexString}"></etherscanlink>
-          <span class="reward-percent">${daoplomat.splitPercentage * deal.registrationData.terms.daoplomatRewards.percentage / 100}</span>
+          <span class="reward-percent">${daoplomat.rewardPercentage * deal.registrationData.terms.daoplomatRewards.percentage / 100}</span>
         </p>
       </div>
     </div>

--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -150,8 +150,8 @@
     >
       <span class="bodySmallTextBold infoTitle">Total DAOplomat Reward</span>
       <span>
-        <span class="percent">
-          ${deal.registrationData.terms.daoplomatRewards.percentageAmount}
+        <span class="reward-percent">
+          ${deal.registrationData.terms.daoplomatRewards.percentage}
         </span>
         <i class="fas fa-angle-down arrow"></i>
       </span>
@@ -166,7 +166,7 @@
             class="representative-dao" 
             address.bind="daoplomat.address"
             text="${daoplomat.address | smallHexString}"></etherscanlink>
-          <span class="percent">${daoplomat.percentageAmount * deal.registrationData.terms.daoplomatRewards.percentageAmount / 100}</span>
+          <span class="reward-percent">${daoplomat.splitPercentage * deal.registrationData.terms.daoplomatRewards.percentage / 100}</span>
         </p>
       </div>
     </div>

--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -166,7 +166,7 @@
             class="representative-dao" 
             address.bind="daoplomat.address"
             text="${daoplomat.address | smallHexString}"></etherscanlink>
-          <span class="reward-percent">${daoplomat.rewardPercentage * deal.registrationData.terms.daoplomatRewards.percentage / 100}</span>
+          <span class="reward-percent">${daoplomat.rewardSplitPercentage * deal.registrationData.terms.daoplomatRewards.percentage / 100}</span>
         </p>
       </div>
     </div>

--- a/src/dealDashboard/dealInfo/dealInfo.scss
+++ b/src/dealDashboard/dealInfo/dealInfo.scss
@@ -153,8 +153,20 @@ deal-info {
         .representative-dao {
           font-weight: 700;
           flex: 1;
+          a {
+            color: $Neutral02;
+          }
         }
       }
+    }
+  }
+
+  .percent{
+    display: inline-flex;
+    color: $Neutral04;
+    &::after {
+      content: "%";
+      display: inline-block;
     }
   }
 }

--- a/src/dealDashboard/dealInfo/dealInfo.scss
+++ b/src/dealDashboard/dealInfo/dealInfo.scss
@@ -161,7 +161,7 @@ deal-info {
     }
   }
 
-  .percent{
+  .reward-percent{
     display: inline-flex;
     color: $Neutral04;
     &::after {

--- a/src/dealDashboard/dealInfo/dealInfo.ts
+++ b/src/dealDashboard/dealInfo/dealInfo.ts
@@ -10,12 +10,18 @@ export class DealInfo {
   private subscriptions = new DisposableCollection();
   private settingPrivacy = false;
 
-  showMore = false;
+  showMoreRepresentatives = false;
+  showMoreRewards: false;
 
-  panel: HTMLElement;
+  panelRepresentatives: HTMLElement;
+  panelRewards: HTMLElement;
 
-  get maxHeight() {
-    return this.showMore ? this.panel.scrollHeight + "px" : "";
+  get maxHeightRepresentatives() {
+    return this.showMoreRepresentatives ? this.panelRepresentatives.scrollHeight + "px" : "";
+  }
+
+  get maxHeightRewards() {
+    return this.showMoreRewards ? this.panelRewards.scrollHeight + "px" : "";
   }
 
   constructor(


### PR DESCRIPTION
## What was done
Added DAOplomats rewards overview to the deal dashboard.

Preview: https://prime-deals-dapp-haq9h3ol7-curvelabs.vercel.app/deal/p4iWee54xZSqcaB2weLP41

![image](https://user-images.githubusercontent.com/2517870/176685021-f4c3dc33-77be-49a6-9bf9-08b69256e5c5.png)

Based on the following data structure:
```js
export interface IDaoplomatReward {
  address: Address,
  rewardSplitPercentage: number // Values: 0-1, sums to `percentage` value | Originally 'percentageAmount'
}

export interface IDaoplomatRewards {
  percentage?: number // Values: 0-1 | Originally 'percentageAmount'
  daoplomats: IDaoplomatReward[]
}

export interface ITerms {
  clauses: Array<IClause>,
  daoplomatRewards?: IDaoplomatRewards
}
```
