### PR TITLE
1085- Documentation duplicated  getting started  page

### DIFF
--- a/src/documentation/documentation.html
+++ b/src/documentation/documentation.html
@@ -4,16 +4,15 @@
     <div class="sidebar">
       <template repeat.for="doc of routes">
         <a
-          if.bind="doc.path"
-          load.bind="doc.path"
-          class.bind="currentPath.includes(doc.path) || (currentPath.includes('documentation') && $index === 1) ? 'active':'not-active'"
+          click.trigger="navigateTo($index)"
+          class="${routes[currentDocIndex].path.includes(doc.path) ? 'active':''}"
         >
           ${doc.title}
         </a>
       </template>
     </div>
     <div class="rightSection">
-      <au-viewport default="" viewport="documents" ></au-viewport>
+      <au-viewport viewport="documents" ></au-viewport>
       <div class="navigationContainer">
         <div click.trigger="previous()" class="navigationPrevious">
           <i class="fas fa-arrow-left" if.to-view="previousDocTitle"></i>

--- a/src/documentation/documentation.html
+++ b/src/documentation/documentation.html
@@ -4,8 +4,9 @@
     <div class="sidebar">
       <template repeat.for="doc of routes">
         <a
-          load="${doc.path}"
-          class="document"
+          if.bind="doc.path"
+          load.bind="doc.path"
+          class.bind="currentPath.includes(doc.path) || (currentPath.includes('documentation') && $index === 1) ? 'active':'not-active'"
         >
           ${doc.title}
         </a>
@@ -25,4 +26,4 @@
       </div>
     </div>
   </div>
-</template>
+</div>

--- a/src/documentation/documentation.ts
+++ b/src/documentation/documentation.ts
@@ -80,7 +80,10 @@ export class Documentation implements IRouteableComponent, ICustomElementViewMod
     });
 
     Documentation.routes.push(...navRoutes);
+  }
 
+  get currentPath() {
+    return this.router.activeNavigation?.instruction;
   }
 
   next(): void {


### PR DESCRIPTION
## What was done

1. Removed default page duplication.
2. Added back navigation buttons and functionality (Next/Previous)
3. Fixed active page highlighting

The recommended `load` attribute in the documentation menu has been replaced with `click.trigger`, due to a bug in Aurelia causing the 'active' class to be reset after a second click on the same link.

#### Before
![image](https://user-images.githubusercontent.com/2517870/177003478-a044250c-c374-4e26-90b6-8edb0f8cde6c.png)

#### After
![image](https://user-images.githubusercontent.com/2517870/177003485-28fbd081-c10f-4ca5-9a16-d854e3f3cf56.png)
