### PR TITLE
1154 - my deals bug

### DIFF
--- a/src/deals/dealSummary/dealSummary.ts
+++ b/src/deals/dealSummary/dealSummary.ts
@@ -19,7 +19,7 @@ export class DealSummary {
     @IRouter private router: IRouter,
   ) { }
 
-  public async attached(): Promise<void> {
+  attached() {
     this.loading = false;
   }
 

--- a/src/deals/list/deals.html
+++ b/src/deals/list/deals.html
@@ -27,7 +27,7 @@
         Initiate a deal
       </pbutton>
     </div>
-    <div class="section no-deals heading02" if.to-view="!dealsLoading && featuredDeals && featuredDeals.length === 0">
+    <div class="section no-deals heading02" if.to-view="!dealsLoading && !allDeals.length">
       ${showMine ? "You are not currently part of any deal" : "No deals are authorized for view" }
       <pbutton
         type="primary"
@@ -39,7 +39,7 @@
     <div data-test="deals-loading" class="section loading" if.to-view="dealsLoading">
       <i class="spinner fa fas fa-circle-notch fa-spin"></i>
     </div>
-    <div class="section deal-carousel" if.to-view="!dealsLoading && (!featuredDeals || featuredDeals.length)">
+    <div class="section deal-carousel" if.to-view="!dealsLoading && gridDeals.length">
       <div class="heading02Gradient carousel-selector">
         <span if.to-view="isTabVisible(0,showMine,ethereumService.defaultAccountAddress)"
           data-test="open-proposals-tab"

--- a/src/deals/list/deals.html
+++ b/src/deals/list/deals.html
@@ -39,7 +39,7 @@
     <div data-test="deals-loading" class="section loading" if.to-view="dealsLoading">
       <i class="spinner fa fas fa-circle-notch fa-spin"></i>
     </div>
-    <div class="section deal-carousel" if.to-view="!dealsLoading && gridDeals.length">
+    <div class="section deal-carousel" if.to-view="!dealsLoading && allDeals.length">
       <div class="heading02Gradient carousel-selector">
         <span if.to-view="isTabVisible(0,showMine,ethereumService.defaultAccountAddress)"
           data-test="open-proposals-tab"

--- a/src/deals/list/deals.ts
+++ b/src/deals/list/deals.ts
@@ -174,13 +174,9 @@ export class Deals {
     this.showMine = !this.showMine;
     if (this.showMine) {
       //if showing only "my deals" check to see which tab to display by default if there are no deals in either tab
-      const openDeals = this.isTabVisible(0, this.showMine, this.ethereumService.defaultAccountAddress);
-      const partneredDeals = this.isTabVisible(1, this.showMine, this.ethereumService.defaultAccountAddress);
-      if (openDeals) {
+      const hasPartneredDeals = this.isTabVisible(1, this.showMine, this.ethereumService.defaultAccountAddress);
+      if (!hasPartneredDeals) {
         this.cardIndex = 0;
-      }
-      else if (partneredDeals) {
-        this.cardIndex = 1;
       }
     }
   }

--- a/src/deals/list/deals.ts
+++ b/src/deals/list/deals.ts
@@ -137,7 +137,7 @@ export class Deals {
   }
 
   private getDealsForCardIndex(cardIndex: number, showMine: boolean, address: string): DealTokenSwap[] {
-    if (this.cardIndex === undefined) {
+    if (cardIndex === undefined) {
       return [];
     }
 
@@ -155,7 +155,11 @@ export class Deals {
 
   private filterDeals(deals: DealTokenSwap[], showMine: boolean, address: string) {
     return showMine
-      ? deals.filter((x: DealTokenSwap) => x.registrationData.proposalLead?.address === address || x.registrationData.primaryDAO?.representatives.some(y => y.address === address))
+      ? deals.filter((x: DealTokenSwap) =>
+        x.registrationData.proposalLead?.address === address
+        || x.registrationData.primaryDAO?.representatives.some(y => y.address === address)
+        || x.registrationData.partnerDAO?.representatives.some(y => y.address === address),
+      )
       : deals;
   }
 


### PR DESCRIPTION
## What was done
Fixed "my deals" button when you have "Partnered deals" tab selected.

First of all, I fixed a bug that showed up when you change the Metamask address. Aurelia, for some reason, cannot handle async router lifecycle hooks. The error was hard to debug but, at the end, I had to remove the `async` keyword from the `attached` lifecycle hook.

This fixed the issue, but in the mean time, I found that the "Open proposal" and "partnered deals" tabs were not displayed if the selected one didn't have any deals. So I fixed that as well. It now shows the other tab if the selected one doesn't have any deals

## Testing

#### Before

#### After