### PR TITLE
1130 - Cannot select clause to discuss

### DIFF
--- a/src/dealDashboard/dealClauses/dealClauses.html
+++ b/src/dealDashboard/dealClauses/dealClauses.html
@@ -3,8 +3,12 @@
     <h2 class="subtitle heading heading3">Deal Clauses</h2>
   </header>
   <ol>
+
+    <!-- Note the `&& clause.id` check in the class attr. -->
+    <!-- Reason: `clause.id` could be `""`, and when no discussion is selected `discussionId` is `""` too -->
+    <!-- Note2: `clause.id` should never be `""`, just make extra sure (see bug Github #1130) -->
     <li
-      class="clause ${authorized? 'isPrivate' : ''} ${discussionId === clause.id ? 'active' : ''}"
+      class="clause ${authorized? 'isPrivate' : ''} ${(discussionId === clause.id) && clause.id ? 'active' : ''}"
       repeat.for="clause of clauses"
     >
       <span class="marker">${$index + 1}</span>

--- a/src/services/FirestoreService.ts
+++ b/src/services/FirestoreService.ts
@@ -387,6 +387,12 @@ export class FirestoreService<
         {merge: true},
       );
     } catch (error) {
+      /**
+       * Debugging note: If FirebaseError says sth about "Document fields must not be empty (found in field clauseDiscussions.``",
+       * then a property is empty, which should not happen!
+       *
+       * Possible solution: Requires to modify Firestore. CAUTION!!
+       */
       throw new Error(error);
     }
 

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
@@ -90,7 +90,7 @@ export class TermsStage {
 
   addClause() {
     const emptyClause: IClause = {
-      id: "",
+      id: shortUuid.generate(),
       text: "",
       title: "",
     };


### PR DESCRIPTION
## What was done
- always generate id when new clause is added
- extra check for existing clauses, that don't have id (ie. id="")

## Testing
0. Note: following is a private deal. Connect to main testing account.
1. https://prime-deals-dapp-git-fix-1130-cannot-select-cl-b8e086-curvelabs.vercel.app/deal/5fVjBaQc36MxuMGqSzizTG

#### Before
clause is "active"

#### After
can select clause