### PR TITLE
The ptoggle input's `change` event was updated to align with the ptoggle AU2 changes

### DIFF
--- a/src/dealDashboard/dealInfo/dealInfo.html
+++ b/src/dealDashboard/dealInfo/dealInfo.html
@@ -220,10 +220,10 @@
     <div class="infoSection dealPrivacyContainer" if.bind="deal.isPartnered" ref="privateDeal">
       <div class="bodySmallTextBold infoTitle">Private Deal</div>
       <ptoggle
-        disabled.bind="!deal.isAuthenticatedProposalLead"
+        disabled.bind="!deal.isAuthenticatedProposalLead || settingPrivacy"
         ptooltip.bind="deal.isAuthenticatedProposalLead ? '' : deal.isPrivate ? 'This deal is private' : 'This deal is public'"
         value.bind="deal.isPrivate"
-        changed.call="changePrivacy($event.checked)"
+        changed.call="changePrivacy($event)"
         class="dealPrivacyToggle"
       ></ptoggle>
     </div>


### PR DESCRIPTION

## What was done
The ptoggle input's `change` event was updated to send the value of the toggle button instead of sending an object containing a `checked` property with the value. 

The usage of ptoggle wasn't updated to align with this change.

I updated the usage of ptoggle to align with the AU2 changes we did.

## Testing

#### Before

#### After