### PR TITLE
1144 - fixed feature of preserving stage settings

### DIFF
--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.html
@@ -24,7 +24,7 @@
           on-delete.call="onDelete($index)"
           on-saved.call="setClause($index, $event)"
           repeat.for="clause of terms.clauses"
-          view-mode.bind="stageMetadata.termsViewModes[$index]"
+          view-mode.bind="stageSettings.termsViewModes[$index]"
           view-model.ref="termClauses[$index]"
         >
         </term-clause>

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termsStage.ts
@@ -25,7 +25,6 @@ export class TermsStage {
 
   termClauses: TermClause[] = [];
   hasUnsavedChanges = false;
-  stageMetadata: {termsViewModes?: ViewMode[]} = {};
 
   terms: ITerms;
   daoplomatRewards?: IDaoplomatRewards;
@@ -39,6 +38,7 @@ export class TermsStage {
   constructor(
     @IContainer public container: IContainer,
     @inject("registrationData") private readonly registrationData: IDealRegistrationTokenSwap,
+    @inject("wizardSettings.terms") private readonly stageSettings: {termsViewModes?: ViewMode[]},
     @IValidationController public form: IValidationController,
     @IValidationRules private validationRules: IValidationRules,
     public numberService: NumberService, // 'numberService' is used by the template
@@ -49,8 +49,7 @@ export class TermsStage {
   }
 
   async load(stageMeta: IStageMeta) {
-    this.stageMetadata = stageMeta.settings ?? {};
-    this.stageMetadata.termsViewModes = this.stageMetadata.termsViewModes ?? this.getDefaultTermsViewModes(stageMeta.wizardType);
+    this.stageSettings.termsViewModes = this.stageSettings.termsViewModes ?? this.getDefaultTermsViewModes(stageMeta.wizardType);
 
     this.terms = this.registrationData.terms;
     this.wizardType = stageMeta.wizardType;
@@ -84,7 +83,7 @@ export class TermsStage {
 
     this.termClauses.splice(index, 1);
     this.registrationData.terms.clauses.splice(index, 1);
-    this.stageMetadata.termsViewModes.splice(index, 1);
+    this.stageSettings.termsViewModes.splice(index, 1);
     this.checkedForUnsavedChanges();
   }
 

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
@@ -18,11 +18,11 @@
       <div class="stageSectionContent">
         <token-details
           hide-delete-button.bind="primaryDaoTokens.length === 1 && !isOpenProposalWizard"
-          on-delete.call="deleteToken($index, primaryDaoTokens, primaryDAOTokenDetails, stageMetadata.primaryDAOTokenDetailsViewModes)"
+          on-delete.call="deleteToken($index, primaryDaoTokens, primaryDAOTokenDetails, stageSettings.primaryDAOTokenDetailsViewModes)"
           on-saved.call="checkedForUnsavedChanges()"
           repeat.for="token of primaryDaoTokens"
           token.bind="token"
-          view-mode.bind="stageMetadata.primaryDAOTokenDetailsViewModes[$index]"
+          view-mode.bind="stageSettings.primaryDAOTokenDetailsViewModes[$index]"
           view-model.ref="primaryDAOTokenDetails[$index]"
           wizard-type.bind="wizardType"></token-details>
 
@@ -55,11 +55,11 @@
       <div class="stageSectionContent">
         <token-details
           hide-delete-button.bind="partnerDaoTokens.length === 1 && !isOpenProposalWizard"
-          on-delete.call="deleteToken($index, partnerDaoTokens, partnerDAOTokenDetails, stageMetadata.partnerDAOTokenDetailsViewModes)"
+          on-delete.call="deleteToken($index, partnerDaoTokens, partnerDAOTokenDetails, stageSettings.partnerDAOTokenDetailsViewModes)"
           on-saved.call="checkedForUnsavedChanges()"
           repeat.for="token of partnerDaoTokens"
           token.bind="token"
-          view-mode.bind="stageMetadata.partnerDAOTokenDetailsViewModes[$index]"
+          view-mode.bind="stageSettings.partnerDAOTokenDetailsViewModes[$index]"
           view-model.ref="partnerDAOTokenDetails[$index]"></token-details>
 
         <pbutton class="addTokenButton" click.delegate="addToken(partnerDaoTokens)"

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
@@ -30,6 +30,7 @@ export class TokenDetailsStage {
 
   constructor(
     @inject("registrationData") private readonly registrationData: IDealRegistrationTokenSwap,
+    @inject("wizardSettings.token-details") private readonly stageSettings: TokenDetailsMetadata,
     @IValidationController public form: IValidationController,
     @IValidationRules private validationRules: IValidationRules,
   ) {
@@ -44,16 +45,15 @@ export class TokenDetailsStage {
   }
 
   load(stageMeta: IStageMeta<TokenDetailsMetadata>): void {
-    this.stageMetadata = stageMeta.settings ?? {};
 
     this.wizardType = stageMeta.wizardType;
     this.isOpenProposalWizard = [WizardType.createOpenProposal, WizardType.editOpenProposal].includes(stageMeta.wizardType);
 
     this.addDefaultValuesToRegistrationData(stageMeta.wizardType);
 
-    this.stageMetadata.primaryDAOTokenDetailsViewModes = this.stageMetadata.primaryDAOTokenDetailsViewModes
+    this.stageSettings.primaryDAOTokenDetailsViewModes = this.stageSettings.primaryDAOTokenDetailsViewModes
       ?? this.getDefaultTokenDetailsViewModes(stageMeta.wizardType, this.registrationData.primaryDAO);
-    this.stageMetadata.partnerDAOTokenDetailsViewModes = this.stageMetadata.partnerDAOTokenDetailsViewModes
+    this.stageSettings.partnerDAOTokenDetailsViewModes = this.stageSettings.partnerDAOTokenDetailsViewModes
       ?? this.getDefaultTokenDetailsViewModes(stageMeta.wizardType, this.registrationData.partnerDAO);
 
     this.primaryDaoTokens = this.registrationData.primaryDAO.tokens;

--- a/src/wizards/tokenSwapDealWizard/wizardManager.ts
+++ b/src/wizards/tokenSwapDealWizard/wizardManager.ts
@@ -249,6 +249,7 @@ export class WizardManager implements IRouteableComponent {
     // It is passed to the wizardService registerWizard method to register it with correct indexOfActive
     this.activeIndex = this.stages.findIndex(stage => stage.route.includes(stageRoute));
 
+    // this is needed to save the stage's state in the current opened wizard
     this.stages.forEach(stage => {
       this.container.register(Registration.instance(`wizardSettings.${stage.route}`, {}));
     });

--- a/src/wizards/tokenSwapDealWizard/wizardManager.ts
+++ b/src/wizards/tokenSwapDealWizard/wizardManager.ts
@@ -163,7 +163,7 @@ export class WizardManager implements IRouteableComponent {
      */
     if (dealId) {
       if (!this.originalRegistrationData) {
-        if (!App.initialized){
+        if (!App.initialized) {
           await App.dealLoadingPromise;
         }
         this.originalRegistrationData = await this.getDeal(dealId);
@@ -248,6 +248,10 @@ export class WizardManager implements IRouteableComponent {
     // Getting the index of currently active stage route.
     // It is passed to the wizardService registerWizard method to register it with correct indexOfActive
     this.activeIndex = this.stages.findIndex(stage => stage.route.includes(stageRoute));
+
+    this.stages.forEach(stage => {
+      this.container.register(Registration.instance(`wizardSettings.${stage.route}`, {}));
+    });
   }
 
   public unload() {
@@ -334,7 +338,7 @@ export class WizardManager implements IRouteableComponent {
       let newDeal: DealTokenSwap;
 
       try {
-        console.info(`Saving deal (Deal ID: ${this.dealId})->`, this.registrationData );
+        console.info(`Saving deal (Deal ID: ${this.dealId})->`, this.registrationData);
         if (creating) {
           // const newDeal = use this for the button link below
           newDeal = await this.dealService.createDeal(this.registrationData);
@@ -395,9 +399,5 @@ export class WizardManager implements IRouteableComponent {
       const tokenDetails: ITokenInfo | undefined = tokensDetails.find(tokenPrice => tokenPrice.symbol === item.symbol);
       return sum + (tokenDetails?.price ?? 0) * (Number(fromWei(item.amount || 0, item.decimals || 0) ?? 0));
     }, 0);
-  }
-
-  dispose() {
-    this.container.disposeResolvers();
   }
 }


### PR DESCRIPTION
## What was done
Saved the stage settings in the container so we can access them later if needed. Each stage has its own settings object that can be accessed using the `wizardSettings.<stage route>` injectable string literal

## Testing

#### Before
This feature was broke by the way AU2 router works so we had to find other solutions. eg: saving settings in the container
#### After
Stage stage is now preserved when switching stages