### PR TITLE
Rich text in dashboard - more styling

### DIFF
--- a/src/dealDashboard/dealClauses/dealClauses.scss
+++ b/src/dealDashboard/dealClauses/dealClauses.scss
@@ -34,6 +34,9 @@ deal-clauses {
 
       .body {
         word-wrap: anywhere;
+        p, li {
+          color: $Neutral02;
+        }
       }
 
       .heading {
@@ -82,11 +85,6 @@ deal-clauses {
       display: flex;
       flex-direction: column;
       width: 100%;
-
-      .body {
-        color: $Neutral02;
-      }
-
     }
 
     @media screen and (max-width: $MaxContentBodyWidth) {

--- a/src/dealDashboard/dealClauses/dealClauses.scss
+++ b/src/dealDashboard/dealClauses/dealClauses.scss
@@ -6,8 +6,7 @@ $hover-transition-speed-medium: 0.3s;
 $hover-transition-speed-slow: 0.4s;
 
 deal-clauses {
-
-  ol {
+  &>ol {
     display: grid;
     gap: $spacing-normal;
     list-style-type: decimal;

--- a/src/dealDashboard/dealClauses/dealClauses.scss
+++ b/src/dealDashboard/dealClauses/dealClauses.scss
@@ -34,11 +34,6 @@ deal-clauses {
 
       .body {
         word-wrap: anywhere;
-
-        small {
-          font-size: 12px;
-          text-overflow: ellipsis;
-        }
       }
 
       .heading {

--- a/src/dealDashboard/dealClauses/dealClauses.scss
+++ b/src/dealDashboard/dealClauses/dealClauses.scss
@@ -6,9 +6,6 @@ $hover-transition-speed-medium: 0.3s;
 $hover-transition-speed-slow: 0.4s;
 
 deal-clauses {
-  p {
-    margin-bottom: 20px;
-  }
 
   ol {
     display: grid;

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.html
@@ -8,10 +8,6 @@
       </div>
     </section>
     <hgroup class="title" ref="refTitle">
-      <pre>
-        <h2 data-test="thread-header" class="heading topic" >${clauses.get(discussionId).title}</h2>
-        <div data-test="thread-content" class="content" innerhtml.to-view="clauses.get(discussionId).text | sanitizeHTML"></div>
-      </pre>
       <span if.bind="dealDiscussion && dealDiscussion.createdBy.address">
         <h3 class="subtext">Clause #${clauseIndex}</h3>
         <h3 class="subtext">
@@ -20,6 +16,9 @@
           at ${ dateService.formattedTime(dealDiscussion.createdAt).short() }
         </h3>
       </span>
+      <pre>
+        <h2 data-test="thread-header" class="heading topic" >${clauses.get(discussionId).title}</h2>
+      </pre>
     </hgroup>
     <div class="sticky-area">
       <section class="comments container">

--- a/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.scss
+++ b/src/dealDashboard/dealDiscussion/discussionThread/discussionThread.scss
@@ -16,7 +16,7 @@
   .title {
     background-color: inherit;
     position: sticky;
-    top: 70px;
+    top: 95px;
     z-index: 1;
     padding-top: $spacing-normal;
     padding-bottom: $spacing-medium-small + $spacing-normal;
@@ -25,12 +25,18 @@
     &>span {
       display: flex;
       justify-content: space-between;
+      align-items: center;
+      height: 60px;
+    }
+
+    pre {
+      white-space: inherit;
     }
 
     .topic {
       font-family: "Inter";
-      font-size: 24px;
-      line-height: 33px;
+      font-size: 20px;
+      line-height: 28px;
       font-weight: 700;
       word-wrap: anywhere;
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -45,24 +45,20 @@ $BodyPaddingLeftRightMobile: calc((100% - #{$ContentBodyWidthMobile}) / 2);
     font-weight: bold;
   }
 
-  ul {
-    margin-bottom: 15px;
-
-    li {
-      list-style-type: disc;
-      list-style-position: inside;
-      margin-bottom: 5px;
-    }
+  p, li {
+    margin-bottom: $spacing-small;
+    color: $Neutral03;
+    font-family: Inter;
   }
 
-  ol {
-    margin-bottom: 15px;
+  ul li {
+    list-style-position: inside;
+    list-style-type: disc;
+  }
 
-    li {
-      list-style-type: decimal;
-      list-style-position: inside;
-      margin-bottom: 5px;
-    }
+  ol li {
+    list-style-position: inside;
+    list-style-type: decimal;
   }
 
   a {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -62,6 +62,6 @@ $BodyPaddingLeftRightMobile: calc((100% - #{$ContentBodyWidthMobile}) / 2);
   }
 
   a {
-    color: #eba7da;
+    color: $Secondary01;
   }
 }

--- a/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.scss
+++ b/src/wizards/tokenSwapDealWizard/stages/submitStage/submitStage.scss
@@ -82,6 +82,9 @@ $submitCardWidth: 645px;
     &.submitTermsCard {
       @include ckeditor-content;
       margin-top: 30px;
+      .heading.topic {
+        color: $White;
+      }
     }
 
     &.submitDaoCard {

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.html
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.html
@@ -16,7 +16,7 @@
         is-vertical
       >
         <!-- Make sure to render new line characters from textarea  -->
-        <div if.bind="clause.title" class="clause__title">${clause.title}</div>
+        <h2 if.bind="clause.title" class="clause__title">${clause.title}</h2>
         <div class="ckEditor__output" innerhtml.to-view="clause.text | sanitizeHTML"></div>
       </pform-input>
     </div>

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.scss
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.scss
@@ -14,7 +14,7 @@ term-clause {
     font-weight: $font-bold;
     margin-bottom: $spacing-normal;
     line-height: 24px;
-    color: $Neutral03;
+    color: $White;
   }
 
   .ck.ck-editor:focus-within {

--- a/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.scss
+++ b/src/wizards/tokenSwapDealWizard/stages/termsStage/termClause/termClause.scss
@@ -1,4 +1,5 @@
 @import "src/resources/elements/primeDesignSystem/variables";
+@import "src/styles/variables";
 
 term-clause {
   display: block;
@@ -23,44 +24,7 @@ term-clause {
 
   .ckEditor__output,
   .ck.ck-content {
-    color: $Neutral03;
-
-    i,
-    em {
-      font-style: italic;
-    }
-
-    u {
-      text-decoration: underline;
-    }
-
-    strong {
-      font-weight: bold;
-    }
-
-    ul {
-      margin-bottom: 15px;
-
-      li {
-        list-style-type: disc;
-        list-style-position: inside;
-        margin-bottom: 5px;
-      }
-    }
-
-    ol {
-      margin-bottom: 15px;
-
-      li {
-        list-style-type: decimal;
-        list-style-position: inside;
-        margin-bottom: 5px;
-      }
-    }
-
-    a {
-      color: #eba7da;
-    }
+    @include ckeditor-content;
   }
 
   .ck.ck-editor__main,


### PR DESCRIPTION
## What was done
The main goal is to achieve WYSIWYG for rich-text elements across the app.

* Adjusted font family, color, and spacing to clause text.
* Removed unnecessary margin
* Fixed OL style leaking
* Removed unused declaration
* Reused `ckeditor` mixin

* Removed description from discussion header.

#### Before
![image](https://user-images.githubusercontent.com/2517870/185975353-63589801-e225-4ada-9070-fa44798a7148.png)

![image](https://user-images.githubusercontent.com/2517870/185981553-5386735f-b7ea-459d-b595-ffe707018d8a.png)

#### After
![image](https://user-images.githubusercontent.com/2517870/185975331-265db062-92c5-4985-b19a-6afeacd3cd7b.png)

![image](https://user-images.githubusercontent.com/2517870/185981114-0dd60506-1209-474b-a757-e36cac85bd4c.png)
