### PR TITLE
1185 - removed the error message for the token details you didn't modify

### DIFF
--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.html
@@ -19,7 +19,6 @@
         <token-details
           hide-delete-button.bind="primaryDaoTokens.length === 1 && !isOpenProposalWizard"
           on-delete.call="deleteToken($index, primaryDaoTokens, primaryDAOTokenDetails, stageSettings.primaryDAOTokenDetailsViewModes)"
-          on-saved.call="checkedForUnsavedChanges()"
           repeat.for="token of primaryDaoTokens"
           token.bind="token"
           view-mode.bind="stageSettings.primaryDAOTokenDetailsViewModes[$index]"
@@ -56,7 +55,6 @@
         <token-details
           hide-delete-button.bind="partnerDaoTokens.length === 1 && !isOpenProposalWizard"
           on-delete.call="deleteToken($index, partnerDaoTokens, partnerDAOTokenDetails, stageSettings.partnerDAOTokenDetailsViewModes)"
-          on-saved.call="checkedForUnsavedChanges()"
           repeat.for="token of partnerDaoTokens"
           token.bind="token"
           view-mode.bind="stageSettings.partnerDAOTokenDetailsViewModes[$index]"

--- a/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
+++ b/src/wizards/tokenSwapDealWizard/stages/tokenDetailsStage/tokenDetailsStage.ts
@@ -74,7 +74,7 @@ export class TokenDetailsStage {
         const forms = this.primaryDAOTokenDetails.filter(Boolean).map(viewModel => viewModel.form);
         const areTokensValid = await areFormsValid(forms);
 
-        this.checkedForUnsavedChanges();
+        this.checkedForUnsavedChangesForPrimaryDao();
 
         return this.hasValidPrimaryDAOTokensDetailsCount &&
           !this.hasUnsavedChangesForPrimaryDetails &&
@@ -94,7 +94,7 @@ export class TokenDetailsStage {
           const forms = this.partnerDAOTokenDetails.filter(Boolean).map(viewModel => viewModel.form);
           const areTokensValid = await areFormsValid(forms);
 
-          this.checkedForUnsavedChanges();
+          this.checkedForUnsavedChangesForPartnerDao();
 
           return !this.hasUnsavedChangesForPartnerDetails &&
             this.hasValidPartnerDAOTokensDetailsCount &&
@@ -135,7 +135,15 @@ export class TokenDetailsStage {
   }
 
   private checkedForUnsavedChanges() {
+    this.checkedForUnsavedChangesForPrimaryDao();
+    this.checkedForUnsavedChangesForPartnerDao();
+  }
+
+  private checkedForUnsavedChangesForPrimaryDao() {
     this.hasUnsavedChangesForPrimaryDetails = this.primaryDAOTokenDetails.filter(viewModel => viewModel?.viewMode === "edit").length > 0;
+  }
+
+  private checkedForUnsavedChangesForPartnerDao() {
     this.hasUnsavedChangesForPartnerDetails = this.partnerDAOTokenDetails.filter(viewModel => viewModel?.viewMode === "edit").length > 0;
   }
 


### PR DESCRIPTION
## What was done
removed the error message for the token details you didn't modify
## Testing

#### Before
We used the same method that checks if the tokens are not save for both token details
#### After
Separated the calls for checking if the tokens are saved or not