### PR TITLE
1179 fixed "after a deal is funded, on page refresh, an error occurs"

### DIFF
--- a/src/entities/DealTokenSwap.ts
+++ b/src/entities/DealTokenSwap.ts
@@ -22,6 +22,7 @@ import TransactionsService, { TransactionReceipt } from "services/TransactionsSe
 import { toBigNumberJs } from "services/BigNumberService";
 import { AureliaHelperService } from "services/AureliaHelperService";
 import { DealService } from "services/DealService";
+import { BehaviorSubject } from "rxjs";
 
 // interface ITokenSwapInfo {
 //   // the participating DAOs
@@ -104,6 +105,7 @@ export class DealTokenSwap implements IDeal {
   private now: Date;
 
   public id: IDealIdType;
+  public loaded$ = new BehaviorSubject(false);
   public dealInitialized: boolean;
   public totalPrice?: number;
   public initializing = true;
@@ -537,6 +539,7 @@ export class DealTokenSwap implements IDeal {
       }
     })
       .finally(() => {
+        this.loaded$.next(true);
         this.initializing = false;
       });
   }

--- a/src/services/EthereumService.ts
+++ b/src/services/EthereumService.ts
@@ -9,6 +9,7 @@ import { formatUnits, getAddress, parseUnits } from "ethers/lib/utils";
 import { Utils } from "./utils";
 import { DI, IEventAggregator, inject } from "aurelia";
 import { DisclaimerService } from "./DisclaimerService";
+import { Subject } from "rxjs";
 
 interface IEIP1193 {
   on(eventName: "accountsChanged", handler: (accounts: Array<Address>) => void);
@@ -110,6 +111,7 @@ export class EthereumService {
   public walletProvider: Web3Provider;
   public defaultAccountAddress: Address;
   public lastBlock: IBlockInfo;
+  public lastBlock$ = new Subject<IBlockInfo>();
   private blockSubscribed: boolean;
   private web3Modal: Web3Modal;
   /**
@@ -358,6 +360,7 @@ export class EthereumService {
   private handleNewBlock = async (blockNumber: number): Promise<void> => {
     const block = await this.getBlock(blockNumber);
     this.lastBlock = block;
+    this.lastBlock$.next(block);
     this.eventAggregator.publish("Network.NewBlock", block);
   };
 


### PR DESCRIPTION
## What was done
Added a few rxjs streams that can be used to wait for some other parts of the app to load. As described below, some part of the app was running without waiting for the deals list to load. 

This approach (with rxjs operators) can be used to remove the `waitUntilTrue` hack we have in Prime Deals and also removing the "race conditions" spread across the app.

## Testing

#### Before
looks like this occurs when:

you just started funding the deal. After aprox 5 min, this error goes away. This is because in the first 5 min, the contract data is taken from moduleContract.on. After 5 min, the contract data is take using moduleContract.queryFilter. The later makes the app not return any errors.
The underlying issue is that we are not waiting for the deals to load when we use moduleContract.on.

waitUntilTrue needs to be removed from Prime Deals. One solution is to use rxjs observables. (check the PR attached to this issue)

#### After